### PR TITLE
Add Distributions page to regain parity with send web mvp

### DIFF
--- a/apps/next/pages/distributions.tsx
+++ b/apps/next/pages/distributions.tsx
@@ -1,0 +1,24 @@
+import { DistributionsScreen } from 'app/features/distributions/screen'
+import Head from 'next/head'
+import { NextPageWithLayout } from './_app'
+import { userProtectedGetSSP } from 'utils/userProtected'
+
+export const Page: NextPageWithLayout = () => {
+  return (
+    <>
+      <Head>
+        <title>Distributions</title>
+        <meta
+          name="description"
+          content="Disributions"
+          key="desc"
+        />
+      </Head>
+      <DistributionsScreen/>
+    </>
+  )
+}
+
+export const getServerSideProps = userProtectedGetSSP()
+
+export default Page

--- a/packages/playwright/tests/distributions.logged-in.spec.ts
+++ b/packages/playwright/tests/distributions.logged-in.spec.ts
@@ -15,6 +15,5 @@ test.beforeEach(async ({ page }) => {
 test('can visit distributions page', async ({ page }) => {
   await page.pause()
   await page.goto('/distributions')
-  // FIXME: This is failing because the user is not eligible for distributions
-  // expect(page).toHaveURL('/distributions')
+  expect(page).toHaveURL('/distributions')
 })


### PR DESCRIPTION
This PR just adds the existing distribution screen as a page. No major changes