### PR TITLE
Use context to share auth images between pages and layouts

### DIFF
--- a/apps/next/pages/sign-in.tsx
+++ b/apps/next/pages/sign-in.tsx
@@ -3,12 +3,20 @@ import Head from 'next/head'
 import { guestOnlyGetSSP } from 'utils/guestOnly'
 import { NextPageWithLayout } from './_app'
 import { AuthLayout } from 'app/features/auth/layout.web'
-import { InferGetServerSidePropsType } from 'next'
 import { getPlaiceholderImage } from 'app/utils/getPlaiceholderImage'
+import { InferGetServerSidePropsType } from 'next'
+import { useContext, useEffect } from 'react'
+import { AuthCarouselContext } from 'app/features/auth/AuthCarouselContext'
 
 export const Page: NextPageWithLayout<InferGetServerSidePropsType<typeof getServerSideProps>> = ({
   images,
 }) => {
+  const { carouselImages, setCarouselImages } = useContext(AuthCarouselContext)
+
+  useEffect(() => {
+    if (carouselImages.length === 0) setCarouselImages(images)
+  }, [setCarouselImages, carouselImages, images])
+
   return (
     <>
       <Head>
@@ -19,7 +27,7 @@ export const Page: NextPageWithLayout<InferGetServerSidePropsType<typeof getServ
           key="desc"
         />
       </Head>
-      <SignInScreen images={images} />
+      <SignInScreen />
     </>
   )
 }

--- a/packages/app/components/sidebar/SignInSideBar.tsx
+++ b/packages/app/components/sidebar/SignInSideBar.tsx
@@ -50,9 +50,7 @@ export const SignInSideBarWrapper = ({ children }: { children?: React.ReactNode 
   const media = useMedia()
   if (media.gtMd) {
     return (
-      <SideBarWrapper sidebar={<SignInSideBar backgroundColor={'$backgroundStrong'} />}>
-        {children}
-      </SideBarWrapper>
+      <SideBarWrapper sidebar={<SignInSideBar bc={'$accentColor'} />}>{children}</SideBarWrapper>
     )
   }
   return children

--- a/packages/app/features/auth/AuthCarouselContext.tsx
+++ b/packages/app/features/auth/AuthCarouselContext.tsx
@@ -1,0 +1,27 @@
+import { type GetPlaiceholderImage } from 'app/utils/getPlaiceholderImage'
+import { Dispatch, SetStateAction, createContext, useContext } from 'react'
+
+export type CarouselImage = { src: string; height: number; width: number; base64?: string }
+export interface AuthCarouselContext {
+  carouselImages: GetPlaiceholderImage[]
+  setCarouselImages: Dispatch<SetStateAction<GetPlaiceholderImage[]>>
+  carouselProgress: number
+  setCarouselProgress: Dispatch<SetStateAction<number>>
+}
+
+const initialState = {
+  carouselImages: [],
+  setCarouselImages: () => {},
+  carouselProgress: 0,
+  setCarouselProgress: () => {},
+}
+
+export const AuthCarouselContext = createContext<AuthCarouselContext>(initialState)
+
+export function useAuthCarouselContext() {
+  const context = useContext(AuthCarouselContext)
+  if (!context) {
+    throw new Error('useAuthCarouselContext must be used within a AuthCarouselContextProvider')
+  }
+  return context
+}

--- a/packages/app/features/auth/layout.web.tsx
+++ b/packages/app/features/auth/layout.web.tsx
@@ -1,16 +1,42 @@
 import { ScrollView, YStack, useWindowDimensions } from '@my/ui'
 
 import { SignInSideBarWrapper } from 'app/components/sidebar/SignInSideBar'
+import { useMemo, useState } from 'react'
+import { AuthCarouselContext } from './AuthCarouselContext'
+import { SolitoImage } from 'solito/image'
+import { type GetPlaiceholderImage } from 'app/utils/getPlaiceholderImage'
 
 export function AuthLayout({ children }: { children: React.ReactNode; header?: string }) {
+  const [carouselImages, setCarouselImages] = useState<GetPlaiceholderImage[]>([])
+  const [carouselProgress, setCarouselProgress] = useState(0)
   const { height: windowHeight } = useWindowDimensions()
-  return (
-    <SignInSideBarWrapper>
-      <YStack h={windowHeight} f={1}>
-        <ScrollView f={3} fb={0} jc="center" backgroundColor={'$backgroundHover'}>
-          {children}
-        </ScrollView>
-      </YStack>
-    </SignInSideBarWrapper>
+
+  const carouselImage = carouselImages[carouselProgress]
+
+  return useMemo(
+    () => (
+      <AuthCarouselContext.Provider
+        value={{ carouselImages, setCarouselImages, carouselProgress, setCarouselProgress }}
+      >
+        <SignInSideBarWrapper>
+          {carouselImage && (
+            <SolitoImage
+              placeholder="blur"
+              blurDataURL={carouselImage.base64}
+              src={carouselImage.img.src}
+              fill={true}
+              style={{ objectFit: 'cover' }}
+              alt="sign-in-carousel"
+            />
+          )}
+          <YStack h={windowHeight} f={1}>
+            <ScrollView f={3} fb={0} jc="center" backgroundColor={'$transparent'}>
+              {children}
+            </ScrollView>
+          </YStack>
+        </SignInSideBarWrapper>
+      </AuthCarouselContext.Provider>
+    ),
+    [carouselImage, carouselImages, carouselProgress, children, windowHeight]
   )
 }

--- a/packages/app/features/auth/sign-in-screen.tsx
+++ b/packages/app/features/auth/sign-in-screen.tsx
@@ -10,124 +10,93 @@ import {
   useWindowDimensions,
 } from '@my/ui'
 import { IconSendLogo } from 'app/components/icons'
-import { SolitoImage } from 'solito/image'
-import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+
+import { useContext, useEffect } from 'react'
 import { SignInForm } from './sign-in-form'
 import { AnimationLayout } from 'app/components/layout/animation-layout'
-import { InferGetStaticPropsType } from 'next'
-import { getServerSideProps } from '../../../../apps/next/pages/sign-in'
+import { AuthCarouselContext } from './AuthCarouselContext'
 
 const screens = ['instant-payments', 'qrcode-payments', 'realtime-payments', 'sign-in-form']
 
-export const SignInScreen = ({ images }: InferGetStaticPropsType<typeof getServerSideProps>) => {
+export const SignInScreen = () => {
   const { height: windowHeight } = useWindowDimensions()
-  const [signInProgress, setSignInProgress] = useState(0)
-  const media = useMedia()
-
-  const incrementProgress = () => {
-    setSignInProgress((i) => (i + 1) % carouselItems.length)
-  }
-
-  const decrementProgress = () => {
-    setSignInProgress((i) => (i - 1 + carouselItems.length) % carouselItems.length)
-  }
+  const { carouselProgress } = useContext(AuthCarouselContext)
 
   const getSignInPage = (page: string | undefined) => {
     switch (true) {
       case page === 'instant-payments' || page === 'qrcode-payments':
-        return (
-          <SignInCarousel
-            signInProgress={signInProgress}
-            buttonRow={<ContinueButton incrementProgress={incrementProgress} />}
-          >
-            <CarouselImage
-              image={images[signInProgress]?.img}
-              imageBase64={images[signInProgress]?.base64}
-            />
-          </SignInCarousel>
-        )
+        return <SignInCarousel buttonRow={<ContinueButton />} />
       case page === 'realtime-payments':
-        return (
-          <SignInCarousel
-            signInProgress={signInProgress}
-            buttonRow={<SignInButtons setSignInProgress={setSignInProgress} />}
-          >
-            <CarouselImage
-              image={images[signInProgress]?.img}
-              imageBase64={images[signInProgress]?.base64}
-            />
-          </SignInCarousel>
-        )
+        return <SignInCarousel buttonRow={<SignInButtons />} />
       case page === 'sign-in-form':
         return <SignInForm />
       default:
-        return (
-          <SignInCarousel signInProgress={0}>
-            {' '}
-            <CarouselImage image={images[0]?.img} imageBase64={images[0]?.base64} />{' '}
-          </SignInCarousel>
-        )
+        return <SignInCarousel />
     }
   }
 
   return (
     <YStack w="100%" h={windowHeight} jc="space-around" mb="auto" mt="auto">
-      <AnimationLayout currentKey={screens[signInProgress] || 'none'} direction={1}>
+      <AnimationLayout currentKey={screens[carouselProgress] || 'none'} direction={1}>
         <Stack py="$5" ai="center" $gtMd={{ dsp: 'none' }}>
           <IconSendLogo size={'$5'} color="$white" />
         </Stack>
-        {getSignInPage(screens[signInProgress])}
+        {getSignInPage(screens[carouselProgress])}
       </AnimationLayout>
     </YStack>
   )
 }
 
-const ContinueButton = ({ incrementProgress }: { incrementProgress: () => void }) => (
-  <Stack w="100%" jc="center" $gtMd={{ dsp: 'none' }} py="$5" gap="$2">
-    <Button f={1} onPress={incrementProgress}>
-      <ButtonText fontWeight={'bold'}>Continue</ButtonText>
-    </Button>
-  </Stack>
-)
+const ContinueButton = () => {
+  const { setCarouselProgress } = useContext(AuthCarouselContext)
+  return (
+    <Stack w="100%" jc="center" $gtMd={{ dsp: 'none' }} py="$5" gap="$2">
+      <Button
+        f={1}
+        onPress={() => setCarouselProgress((progress) => (progress + 1) % carouselItems.length)}
+      >
+        <ButtonText fontWeight={'bold'}>Continue</ButtonText>
+      </Button>
+    </Stack>
+  )
+}
 
-const SignInButtons = ({
-  setSignInProgress,
-}: { setSignInProgress: Dispatch<SetStateAction<number>> }) => (
-  <XStack f={1} w="100%" jc="center" $gtMd={{ dsp: 'none' }} py="$5" gap="$2">
-    <Button f={1} onPress={() => setSignInProgress(3)}>
-      <ButtonText fontWeight={'bold'} col="$backgroundStrong">
-        Login
-      </ButtonText>
-    </Button>
-    <Button
-      f={1}
-      bc="background05"
-      borderColor="$backgroundStrong"
-      bw={'$1'}
-      onPress={() => setSignInProgress(3)}
-    >
-      <ButtonText fontWeight={'bold'} col="$backgroundStrong">
-        Sign up
-      </ButtonText>
-    </Button>
-  </XStack>
-)
+const SignInButtons = () => {
+  const { setCarouselProgress } = useContext(AuthCarouselContext)
+  return (
+    <XStack w="100%" jc="center" $gtMd={{ dsp: 'none' }} py="$5" gap="$2">
+      <Button f={1} onPress={() => setCarouselProgress(carouselItems.length)}>
+        <ButtonText fontWeight={'bold'} col="$backgroundStrong">
+          Login
+        </ButtonText>
+      </Button>
+      <Button
+        f={1}
+        bc="background05"
+        borderColor="$backgroundStrong"
+        bw={'$1'}
+        onPress={() => setCarouselProgress(carouselItems.length)}
+      >
+        <ButtonText fontWeight={'bold'} col="$backgroundStrong">
+          Sign up
+        </ButtonText>
+      </Button>
+    </XStack>
+  )
+}
 
 const carouselItems = [
   {
-    url: 'https://github.com/0xsend/assets/blob/main/app_images/bg_image_dark_1.jpg?raw=true',
     line1: 'INSTANT',
     line2: 'PAYMENTS',
     description: 'INFRASTRUCTURE FOR MERCHANTS AND STABLECOIN TRANSACTIONS',
   },
   {
-    url: 'https://github.com/0xsend/assets/blob/main/app_images/bg_image_dark_1.jpg?raw=true',
     line1: 'QRCODE',
     line2: 'PAYMENTS',
     description: 'INFRASTRUCTURE FOR MERCHANTS AND STABLECOIN TRANSACTIONS',
   },
   {
-    url: 'https://github.com/0xsend/assets/blob/main/app_images/bg_image_dark_1.jpg?raw=true',
     line1: 'REAL TIME',
     line2: 'PAYMENTS',
     description: 'INFRASTRUCTURE FOR MERCHANTS AND STABLECOIN TRANSACTIONS',
@@ -135,33 +104,27 @@ const carouselItems = [
 ]
 
 const SignInCarousel = ({
-  signInProgress = 0,
-  setSignInProgress,
-  children,
   buttonRow,
 }: {
-  signInProgress: number
-  setSignInProgress?: Dispatch<SetStateAction<number>> | undefined
   buttonRow?: React.ReactNode
-  children?: React.ReactNode
 }) => {
   const media = useMedia()
+  const { carouselProgress, setCarouselProgress } = useContext(AuthCarouselContext)
 
   useEffect(() => {
     if (media.gtMd) {
       const interval = setInterval(() => {
-        setSignInProgress?.((progress) => (progress + 1) % carouselItems.length)
+        setCarouselProgress((progress) => (progress + 1) % carouselItems.length)
       }, 7500)
       return () => clearInterval(interval)
     }
-  }, [media, setSignInProgress])
+  }, [media, setCarouselProgress])
 
-  const item = carouselItems.at(signInProgress)
+  const item = carouselItems.at(carouselProgress)
 
   return (
     <View pos="absolute" h={'100%'} w={'100%'} top={0} left={0} mt="auto" mb="auto" zIndex={-1}>
       <Stack mt="auto" mb="auto" w="100%" h="100%">
-        {children}
         <YStack jc="flex-end" h="100%">
           <Text fontSize="$8" $gtXs={{ fontSize: '$13' }} fontWeight={'bold'} color="$white">
             {item?.line1}
@@ -178,44 +141,6 @@ const SignInCarousel = ({
           {buttonRow}
         </YStack>
       </Stack>
-    </View>
-  )
-}
-
-const CarouselImage = ({
-  image,
-  imageBase64,
-}: {
-  image?: {
-    src: string
-    height: number
-    width: number
-  }
-  imageBase64?: string
-}) => {
-  return (
-    <View
-      pos="absolute"
-      h={'100%'}
-      w={'100%'}
-      top={0}
-      left={0}
-      mt="auto"
-      mb="auto"
-      zIndex={-1}
-      bc="$background"
-    >
-      {image?.src && (
-        <SolitoImage
-          placeholder="blur"
-          blurDataURL={imageBase64}
-          src={image.src}
-          fill={true}
-          style={{ objectFit: 'cover' }}
-          contentPosition={{ left: '65%' }}
-          alt="sign-in-carousel"
-        />
-      )}
     </View>
   )
 }

--- a/packages/app/utils/getPlaiceholderImage.ts
+++ b/packages/app/utils/getPlaiceholderImage.ts
@@ -1,4 +1,7 @@
-import { getPlaiceholder, GetPlaiceholderOptions } from 'plaiceholder'
+import { getPlaiceholder, GetPlaiceholderOptions, GetPlaiceholderReturn } from 'plaiceholder'
+type img = { src: string; height: number; width: number }
+
+export type GetPlaiceholderImage = ({ img: img } & Omit<GetPlaiceholderReturn, 'metadata'>) | null
 
 export const getPlaiceholderImage = async (src: string, options?: GetPlaiceholderOptions) => {
   const buffer = await fetch(src)

--- a/packages/ui/src/components/SideBar/index.tsx
+++ b/packages/ui/src/components/SideBar/index.tsx
@@ -1,19 +1,24 @@
-import { YStack, YStackProps } from 'tamagui'
+import { YStack, YStackProps, useWindowDimensions } from 'tamagui'
 
 export const SideBar = ({
   children,
   width,
   ...props
 }: { children?: React.ReactNode } & YStackProps) => {
+  const dimensions = useWindowDimensions()
   return (
     <YStack
-      height={'100svh'}
+      height={dimensions.height - 80}
       width={width || '20%'}
       py="$6"
+      ml="$7"
+      my="auto"
       zIndex={1}
       justifyContent="space-around"
       alignItems="center"
-      mih={'524px'}
+      mih={524}
+      miw={395}
+      br={'$8'}
       {...props}
     >
       {children}


### PR DESCRIPTION
To have the image display behind the sidebar, we need it to render in the layout component. Context lets us render the images in layout, while controlling them in the page