### PR TITLE
Fix linter errors/warnings

### DIFF
--- a/packages/app/components/icons/IconLogout.tsx
+++ b/packages/app/components/icons/IconLogout.tsx
@@ -1,24 +1,7 @@
 import type { IconProps } from '@tamagui/helpers-icon'
 import { themed } from '@tamagui/helpers-icon'
-import PropTypes from 'prop-types'
 import React, { memo } from 'react'
-import {
-  Circle as _Circle,
-  Defs,
-  Ellipse,
-  G,
-  Line,
-  LinearGradient,
-  Path,
-  Polygon,
-  Polyline,
-  RadialGradient,
-  Rect,
-  Stop,
-  Svg,
-  Text as _Text,
-  Use,
-} from 'react-native-svg'
+import { Line, Path, Polyline, Svg } from 'react-native-svg'
 import { ColorTokens } from '@my/ui/types'
 
 const Icon = (props: IconProps) => {

--- a/packages/app/components/sidebar/HomeSideBar.tsx
+++ b/packages/app/components/sidebar/HomeSideBar.tsx
@@ -9,15 +9,7 @@ import {
   useMedia,
 } from '@my/ui'
 import { Link } from '@my/ui'
-import {
-  IconAccount,
-  IconActivity,
-  IconDashboard,
-  IconDistributions,
-  IconHome,
-  IconSLogo,
-  IconSendLogo,
-} from 'app/components/icons'
+import { IconAccount, IconActivity, IconHome, IconSLogo, IconSendLogo } from 'app/components/icons'
 import { SideBarNavLink } from 'app/components/sidebar/SideBarNavLink'
 
 import { useNav } from 'app/routers/params'

--- a/packages/app/components/sidebar/SideBarNavLink.tsx
+++ b/packages/app/components/sidebar/SideBarNavLink.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonIcon, ButtonText, Link, Theme, type LinkProps } from '@my/ui'
+import { Button, ButtonIcon, ButtonText, Link, type LinkProps } from '@my/ui'
 import { usePathname } from 'app/utils/usePathname'
 import { type ReactElement } from 'react'
 import { useThemeSetting } from '@tamagui/next-theme'

--- a/packages/app/features/account/changePhone.tsx
+++ b/packages/app/features/account/changePhone.tsx
@@ -1,15 +1,12 @@
 import {
   Fieldset,
-  H2,
   Input,
   Label,
   SubmitButton,
-  Theme,
   YStack,
   isWeb,
   useToastController,
   XStack,
-  Button,
   Paragraph,
   Container,
 } from '@my/ui'

--- a/packages/app/features/account/components/editProfile/screen.tsx
+++ b/packages/app/features/account/components/editProfile/screen.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Button, Container, Paragraph, XStack, YStack, Label, SubmitButton } from '@my/ui'
+import { Avatar, Container, Paragraph, XStack, YStack, Label, SubmitButton } from '@my/ui'
 import { SchemaForm } from 'app/utils/SchemaForm'
 import { useEditProfileMutation, ProfileSchema } from 'app/utils/useEditProfileMutation'
 import { useUser } from 'app/utils/useUser'

--- a/packages/app/features/account/components/uploadProfileImage/screen.tsx
+++ b/packages/app/features/account/components/uploadProfileImage/screen.tsx
@@ -1,4 +1,4 @@
-import { Paragraph, SizableText, Theme, YStack } from '@my/ui'
+import { SizableText, YStack } from '@my/ui'
 import { Upload } from '@tamagui/lucide-icons'
 import { useSupabase } from 'app/utils/supabase/useSupabase'
 import { useUser } from 'app/utils/useUser'

--- a/packages/app/features/auth/components/VerifyCode.tsx
+++ b/packages/app/features/auth/components/VerifyCode.tsx
@@ -2,7 +2,6 @@ import {
   BigHeading,
   ButtonText,
   FormWrapper,
-  H1,
   H3,
   Paragraph,
   SubmitButton,

--- a/packages/app/features/auth/onboarding/screen.tsx
+++ b/packages/app/features/auth/onboarding/screen.tsx
@@ -7,9 +7,19 @@
  * - Generate a deterministic address from the public key
  * - Ask the user to deposit funds
  */
-import { Paragraph, Stack, YStack, Theme, useMedia, useToastController, Button } from '@my/ui'
+import {
+  Paragraph,
+  Stack,
+  YStack,
+  Theme,
+  useMedia,
+  useToastController,
+  Button,
+  H3,
+  XStack,
+} from '@my/ui'
 import { useSendAccounts } from 'app/utils/send-accounts'
-import { IconSendLogo } from 'app/components/icons'
+import { IconCopy, IconSendLogo } from 'app/components/icons'
 import { OnboardingForm } from './onboarding-form'
 import { Carousel } from '../components/Carousel'
 import { testClient } from 'app/utils/userop'
@@ -17,6 +27,7 @@ import { parseEther } from 'viem'
 import { setERC20Balance } from 'app/utils/useSetErc20Balance'
 import { baseMainnetClient, sendTokenAddress, usdcAddress } from '@my/wagmi'
 import { useAuthCarouselContext } from 'app/features/auth/AuthCarouselContext'
+import { shorten } from 'app/utils/strings'
 
 export function OnboardingScreen() {
   const { carouselProgress } = useAuthCarouselContext()

--- a/packages/app/features/leaderboard/screen.tsx
+++ b/packages/app/features/leaderboard/screen.tsx
@@ -1,4 +1,4 @@
-import { Button, Container, KVTable, Paragraph, XStack, YStack } from '@my/ui'
+import { Container, Paragraph, XStack, YStack } from '@my/ui'
 
 const users = [
   {

--- a/packages/app/utils/distributions.ts
+++ b/packages/app/utils/distributions.ts
@@ -11,7 +11,7 @@ import {
 import { PostgrestError } from '@supabase/supabase-js'
 import { UseQueryResult, useQuery } from '@tanstack/react-query'
 import { useSupabase } from 'app/utils/supabase/useSupabase'
-import { useBalance, useChainId, useReadContract, useSimulateContract } from 'wagmi'
+import { useBalance, useReadContract, useSimulateContract } from 'wagmi'
 import { api } from './api'
 
 export const DISTRIBUTION_INITIAL_POOL_AMOUNT = BigInt(20e9)


### PR DESCRIPTION
Fixed 99% of the warnings thrown by the linter about unused variables/ imports

Also fixed errors about missing imports for SecretStore

One lint warning remains in the useSendAccountBalances hook. It is calling a react hook in a for loop, which is problematic and can cause unexpected crashes. This necessitates a refactor, which I will submit in a future PR