### PR TITLE
Update Profile search backend functions.

### DIFF
--- a/.snaplet/snaplet-client.d.ts
+++ b/.snaplet/snaplet-client.d.ts
@@ -98,6 +98,7 @@ type Override = {
       qualification_start?: string;
       qualification_end?: string;
       claim_end?: string;
+      snapshot_id?: string;
       hodler_min_balance?: string;
       created_at?: string;
       updated_at?: string;
@@ -522,6 +523,7 @@ export interface Fingerprint {
     qualificationStart?: FingerprintDateField;
     qualificationEnd?: FingerprintDateField;
     claimEnd?: FingerprintDateField;
+    snapshotId?: FingerprintNumberField;
     hodlerMinBalance?: FingerprintNumberField;
     createdAt?: FingerprintDateField;
     updatedAt?: FingerprintDateField;

--- a/.snaplet/snaplet.d.ts
+++ b/.snaplet/snaplet.d.ts
@@ -89,6 +89,7 @@ interface Table_public_distributions {
   qualification_start: string;
   qualification_end: string;
   claim_end: string;
+  snapshot_id: number | null;
   hodler_min_balance: number;
   created_at: string;
   updated_at: string;

--- a/packages/app/features/activity/__snapshots__/screen.test.tsx.snap
+++ b/packages/app/features/activity/__snapshots__/screen.test.tsx.snap
@@ -3901,7 +3901,6 @@ exports[`ActivityScreen: search: ActivityScreen: search 1`] = `
     style={
       {
         "flexDirection": "column",
-        "gap": 18,
         "marginBottom": 18,
         "opacity": 0,
         "transform": [
@@ -3935,6 +3934,38 @@ exports[`ActivityScreen: search: ActivityScreen: search 1`] = `
       Results
     </Text>
     <View
+      pointerEvents="none"
+      style={
+        {
+          "height": 18,
+          "minHeight": 18,
+          "minWidth": 18,
+          "width": 18,
+        }
+      }
+    />
+    <Text
+      accessibilityRole="header"
+      selectable={true}
+      style={
+        {
+          "color": "hsla(191, 32%, 46%, 1)",
+          "fontFamily": "System",
+          "fontSize": 20,
+          "fontWeight": "700",
+          "lineHeight": 24,
+          "marginBottom": 0,
+          "marginLeft": 0,
+          "marginRight": 0,
+          "marginTop": 0,
+          "textTransform": "none",
+        }
+      }
+      suppressHighlighting={true}
+    >
+      tag_matches
+    </Text>
+    <View
       data-href="/profile/test"
     >
       <View
@@ -3942,7 +3973,6 @@ exports[`ActivityScreen: search: ActivityScreen: search 1`] = `
           {
             "alignItems": "center",
             "flexDirection": "row",
-            "gap": 18,
           }
         }
         testID="tag-search-test"
@@ -3956,7 +3986,6 @@ exports[`ActivityScreen: search: ActivityScreen: search 1`] = `
               "borderTopLeftRadius": 9,
               "borderTopRightRadius": 9,
               "flexDirection": "column",
-              "gap": 7,
               "height": 44,
               "justifyContent": "center",
               "maxHeight": 44,
@@ -3999,6 +4028,17 @@ exports[`ActivityScreen: search: ActivityScreen: search 1`] = `
               }
             />
           </View>
+          <View
+            pointerEvents="none"
+            style={
+              {
+                "height": 7,
+                "minHeight": 7,
+                "minWidth": 7,
+                "width": 7,
+              }
+            }
+          />
           <View
             style={
               {
@@ -4092,10 +4132,20 @@ exports[`ActivityScreen: search: ActivityScreen: search 1`] = `
           </View>
         </View>
         <View
+          pointerEvents="none"
+          style={
+            {
+              "height": 18,
+              "minHeight": 18,
+              "minWidth": 18,
+              "width": 18,
+            }
+          }
+        />
+        <View
           style={
             {
               "flexDirection": "column",
-              "gap": 2,
             }
           }
         >

--- a/packages/app/features/activity/screen.test.tsx
+++ b/packages/app/features/activity/screen.test.tsx
@@ -9,8 +9,15 @@ jest.mock('app/utils/supabase/useSupabase', () => ({
       abortSignal: jest.fn().mockReturnValue({
         data: [
           {
-            tag_name: 'test',
-            avatar_url: 'https://avatars.githubusercontent.com/u/123',
+            send_id_matches: [],
+            tag_matches: [
+              {
+                send_id: 3665,
+                tag_name: 'test',
+                avatar_url: 'https://avatars.githubusercontent.com/u/123',
+              },
+            ],
+            phone_matches: [],
           },
         ],
         error: null,

--- a/packages/app/features/activity/screen.tsx
+++ b/packages/app/features/activity/screen.tsx
@@ -134,12 +134,14 @@ function SearchResults() {
     return null
   }
 
+  const result = results[0] // Access the first element of the results array
+
   return (
     <YStack
       testID="searchResults"
       key="searchResults"
       animation="quick"
-      gap="$4"
+      space="$4"
       mb="$4"
       enterStyle={{
         opacity: 0,
@@ -147,29 +149,39 @@ function SearchResults() {
       }}
     >
       <H4 theme={'alt2'}>Results</H4>
-      {results.length === 0 && <Text>No results for {query}... 😢</Text>}
-      {results.map((result) => (
-        <Link key={result.tag_name} href={`/profile/${result.tag_name}`}>
-          <XStack testID={`tag-search-${result.tag_name}`} ai="center" gap="$4">
-            <Avatar size="$4" br="$4" gap="$2">
-              <Avatar.Image src={result.avatar_url} />
-              <Avatar.Fallback>
-                <Avatar>
-                  <Avatar.Image
-                    src={`https://ui-avatars.com/api.jpg?name=${result.tag_name}&size=256`}
-                  />
-                  <Avatar.Fallback>
-                    <Paragraph>??</Paragraph>
-                  </Avatar.Fallback>
-                </Avatar>
-              </Avatar.Fallback>
-            </Avatar>
-            <YStack gap="$1">
-              <Text>{result.tag_name}</Text>
-            </YStack>
-          </XStack>
-        </Link>
-      ))}
+      {result.send_id_matches?.length === 0 &&
+        result.tag_matches?.length === 0 &&
+        result.phone_matches?.length === 0 && <Text>No results for {query}... 😢</Text>}
+      {['send_id_matches', 'tag_matches', 'phone_matches'].map(
+        (key) =>
+          result[key]?.length > 0 && (
+            <>
+              <H4 theme={'alt2'}>{key}</H4>
+              {result[key].map((result) => (
+                <Link key={result.tag_name} href={`/profile/${result.tag_name}`}>
+                  <XStack testID={`tag-search-${result.tag_name}`} ai="center" space="$4">
+                    <Avatar size="$4" br="$4" space="$2">
+                      <Avatar.Image src={result.avatar_url} />
+                      <Avatar.Fallback>
+                        <Avatar>
+                          <Avatar.Image
+                            src={`https://ui-avatars.com/api.jpg?name=${result.tag_name}&size=256`}
+                          />
+                          <Avatar.Fallback>
+                            <Paragraph>??</Paragraph>
+                          </Avatar.Fallback>
+                        </Avatar>
+                      </Avatar.Fallback>
+                    </Avatar>
+                    <YStack space="$1">
+                      <Text>{result.tag_name}</Text>
+                    </YStack>
+                  </XStack>
+                </Link>
+              ))}
+            </>
+          )
+      )}
     </YStack>
   )
 }

--- a/packages/app/provider/tag-search/TagSearchProvider.tsx
+++ b/packages/app/provider/tag-search/TagSearchProvider.tsx
@@ -30,7 +30,7 @@ async function searchTags({ supabase, query }: SearchTagsArgs) {
   }
   abortController = new AbortController()
   const { data, error } = await supabase
-    .rpc('tag_search', { query })
+    .rpc('tag_search', { query, limit_val: 10 })
     .abortSignal(abortController.signal)
   return { data, error }
 }
@@ -68,8 +68,8 @@ export const TagSearchProvider = ({ children }: { children: React.ReactNode }) =
   const query = form.watch('query', '')
 
   useEffect(() => {
-    if (query.length >= 2) {
-      onSearch({ query })
+    if (query.length >= 1) {
+      onSearch({ query, limit_val: 10 })
     } else {
       setIsLoading(false)
       setError(null)

--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -186,6 +186,7 @@ export type Database = {
           qualification_end: string
           qualification_start: string
           snapshot_block_num: number | null
+          snapshot_id: number | null
           updated_at: string
         }
         Insert: {
@@ -204,6 +205,7 @@ export type Database = {
           qualification_end: string
           qualification_start: string
           snapshot_block_num?: number | null
+          snapshot_id?: number | null
           updated_at?: string
         }
         Update: {
@@ -222,6 +224,7 @@ export type Database = {
           qualification_end?: string
           qualification_start?: string
           snapshot_block_num?: number | null
+          snapshot_id?: number | null
           updated_at?: string
         }
         Relationships: []
@@ -916,15 +919,19 @@ export type Database = {
           address: string
           chain_id: number
           is_public: boolean
+          send_id: number
         }[]
       }
       tag_search: {
         Args: {
           query: string
+          limit_val?: number
+          offset_val?: number
         }
         Returns: {
-          avatar_url: string
-          tag_name: string
+          send_id_matches: Json
+          tag_matches: Json
+          phone_matches: Json
         }[]
       }
       update_distribution_shares: {

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -83,7 +83,7 @@ export type Database = MergeDeep<
             address: `0x${string}`
             chain_id: number
             is_public: boolean | null
-            send_id: number | null
+            send_id: number
           }[]
           tag_search: {
             Returns: {

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -83,8 +83,34 @@ export type Database = MergeDeep<
             address: `0x${string}`
             chain_id: number
             is_public: boolean | null
-            send_id: number
+            send_id: number | null
           }[]
+          tag_search: {
+            Returns: {
+              send_id_matches: [
+                {
+                  send_id: number | null
+                  tag_name: string
+                  avatar_url: string | null
+                },
+              ]
+              tag_matches: [
+                {
+                  tag_name: string
+                  avatar_url: string | null
+                  send_id: number | null
+                },
+              ]
+              phone_matches: [
+                {
+                  phone: string
+                  avatar_url: string | null
+                  send_id: number | null
+                  tag_name: string | null
+                },
+              ]
+            }
+          }
         }
       }
     }

--- a/supabase/migrations/20240122020348_create_profile_lookup_function.sql
+++ b/supabase/migrations/20240122020348_create_profile_lookup_function.sql
@@ -8,7 +8,8 @@ create or replace function public.profile_lookup(tag text)
     tag_name citext,
     address citext,
     chain_id integer,
-    is_public boolean)
+    is_public boolean,
+    send_id integer)
   language plpgsql
   immutable
   security definer
@@ -28,7 +29,8 @@ begin
     sa.chain_id as chain_id,
     case when current_setting('role')::text = 'service_role' then
       p.is_public
-    end as is_public
+    end as is_public,
+    p.send_id as send_id
   from
     profiles p
     join tags t on t.user_id = p.id

--- a/supabase/migrations/20240415200034_update_tag_search_function.sql
+++ b/supabase/migrations/20240415200034_update_tag_search_function.sql
@@ -1,0 +1,103 @@
+
+drop function if exists public.tag_search(q text);
+create or replace function public.tag_search(
+        query text,
+        limit_val integer = NULL,
+        offset_val integer = NULL
+    ) returns table(
+        send_id_matches jsonb,
+        tag_matches jsonb,
+        phone_matches jsonb
+    ) language plpgsql immutable security definer as $function$ begin return query --
+  select
+    COALESCE(
+        (
+            select jsonb_agg(
+                    jsonb_strip_nulls(
+                        jsonb_build_object(
+                            'avatar_url',
+                            avatar_url,
+                            'tag_name',
+                            name,
+                            'send_id',
+                            send_id
+                        )
+                    )
+                )
+            from (
+                    select p.avatar_url,
+                        t.name,
+                        p.send_id
+                    from profiles p
+                        join tags t on t.user_id = p.id
+                    where query SIMILAR TO '\d+'
+                        and p.send_id::varchar ilike '%' || query || '%'
+                    order by p.send_id
+                    LIMIT limit_val OFFSET offset_val
+                ) sub
+        ),
+        '[]'
+    ) as send_id_matches,
+    COALESCE(
+        (
+            select jsonb_agg(
+                    jsonb_strip_nulls(
+                        jsonb_build_object(
+                            'avatar_url',
+                            avatar_url,
+                            'tag_name',
+                            name,
+                            'send_id',
+                            send_id
+                        )
+                    )
+                )
+            from (
+                    select p.avatar_url,
+                        t.name,
+                        p.send_id
+                    from profiles p
+                        join tags t on t.user_id = p.id
+                    where t.name ILIKE '%' || query || '%'
+                    order by (t.name <->query) asc
+                    LIMIT limit_val OFFSET offset_val
+                ) sub
+        ),
+        '[]'
+    ) as tag_matches,
+    COALESCE(
+        (
+            select jsonb_agg(
+                    jsonb_strip_nulls(
+                        jsonb_build_object(
+                            'avatar_url',
+                            avatar_url,
+                            'phone',
+                            phone,
+                            'tag_name',
+                            tag_name,
+                            'send_id',
+                            send_id
+                        )
+                    )
+                )
+            from (
+                    select p.avatar_url,
+                        u.phone,
+                        t.name as tag_name,
+                        p.send_id
+                    from profiles p
+                        join tags t on t.user_id = p.id
+                        join auth.users u on u.id = p.id
+                    where query ~ '^\d{6,}$'
+                        and u.phone like query || '%'
+                    order by u.phone
+                    LIMIT limit_val OFFSET offset_val
+                ) sub
+        ),
+        '[]'
+    ) as phone_matches;
+end;
+$function$;
+
+revoke all on function public.tag_search(q text, limit_val int, offset_val int) from anon;

--- a/supabase/tests/profile_lookup_test.sql
+++ b/supabase/tests/profile_lookup_test.sql
@@ -10,36 +10,47 @@ insert into tags(user_id, name, status)
   values (tests.get_supabase_uid('valid_tag_user'), 'valid_tag', 'confirmed');
 insert into send_accounts(user_id, address, chain_id, init_code)
   values (tests.get_supabase_uid('valid_tag_user'), '0x1234567890ABCDEF1234567890ABCDEF12345678', 1, '\\x00112233445566778899AABBCCDDEEFF');
+
+DO $$
+DECLARE
+  sendid int;
+BEGIN
+  sendid := (SELECT send_id FROM public.profile_lookup('valid_tag'));
+  RAISE NOTICE '%', sendid;
+  EXECUTE format('SET SESSION "vars.send_id" TO %L', sendid);
+END;
+$$ LANGUAGE plpgsql;
+
 -- Test valid tag lookup as authenticated user
 select
   tests.authenticate_as('valid_tag_user');
 select
   results_eq($$
     select
-      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public from
+      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public, send_id from
 	public.profile_lookup('valid_tag') $$, $$
     values (tests.get_supabase_uid('valid_tag_user'), null, null, null, 'valid_tag'::citext,
-      '0x1234567890abcdef1234567890abcdef12345678'::citext, 1, null::boolean) $$, 'Test valid tag lookup as authenticated user');
+      '0x1234567890abcdef1234567890abcdef12345678'::citext, 1, null::boolean, (select current_setting('vars.send_id')::int)) $$, 'Test valid tag lookup as authenticated user');
 -- Test valid tag lookup as service role
 select
   tests.authenticate_as_service_role();
 select
   results_eq($$
     select
-      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public from
+      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public, send_id from
 	public.profile_lookup('valid_tag') $$, $$
     values (null::uuid, null, null, null, 'valid_tag'::citext, '0x1234567890abcdef1234567890abcdef12345678'::citext, 1,
-      true) $$, 'Test valid tag lookup as service role');
+      true, (select current_setting('vars.send_id')::int)) $$, 'Test valid tag lookup as service role');
 -- Test valid tag lookup as anon
 select
   tests.clear_authentication();
 select
   results_eq($$
     select
-      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public from
+      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public, send_id from
 	public.profile_lookup('valid_tag') $$, $$
     values (null::uuid, null, null, null, 'valid_tag'::citext, '0x1234567890abcdef1234567890abcdef12345678'::citext, 1,
-      null::boolean) $$, 'Test valid tag lookup as anon');
+      null::boolean, (select current_setting('vars.send_id')::int)) $$, 'Test valid tag lookup as anon');
 -- Start tests for is_public
 select
   tests.authenticate_as_service_role();
@@ -55,27 +66,27 @@ select
 select
   results_eq($$
     select
-      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public from
+      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public, send_id from
 	public.profile_lookup('valid_tag') $$, $$
     values (tests.get_supabase_uid('valid_tag_user'), null, null, null, 'valid_tag'::citext,
-      '0x1234567890abcdef1234567890abcdef12345678'::citext, 1, null::boolean) $$, 'Test valid tag lookup as authenticated user');
+      '0x1234567890abcdef1234567890abcdef12345678'::citext, 1, null::boolean, (select current_setting('vars.send_id')::int)) $$, 'Test valid tag lookup as authenticated user');
 -- Test valid tag lookup as service role
 select
   tests.authenticate_as_service_role();
 select
   results_eq($$
     select
-      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public from
+      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public, send_id from
 	public.profile_lookup('valid_tag') $$, $$
     values (null::uuid, null, null, null, 'valid_tag'::citext, '0x1234567890abcdef1234567890abcdef12345678'::citext, 1,
-      false) $$, 'Test valid tag lookup as service role');
+      false, (select current_setting('vars.send_id')::int)) $$, 'Test valid tag lookup as service role');
 -- Test invalid tag lookup as anon
 select
   tests.clear_authentication();
 select
   is_empty($$
     select
-      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public from
+      id::uuid, avatar_url, name, about, tag_name, address, chain_id, is_public, send_id from
 	public.profile_lookup('invalid_tag') $$, 'Test invalid tag lookup as anon');
 select
   tests.authenticate_as('valid_tag_user');

--- a/supabase/tests/tags_search_test.sql
+++ b/supabase/tests/tags_search_test.sql
@@ -31,8 +31,7 @@ select
 -- Verify that the tags are visible to the public
 select
   results_eq($$
-    select
-      count(*)::integer from tag_search('zzz') $$, $$
+  SELECT jsonb_array_length(tag_matches) from tag_search('zzz'); $$, $$
     values (4) $$, 'Tags should be visible to the public');
 select
   *


### PR DESCRIPTION
Update Profile Search function to accomodate searching for sendid, tag or phone number , result from tag_search will now be a list of objects representing matches for sendid, phone number or tag there is also two new arguments to the function that will take limit and offset parameters and pass those values to the subqueries, this can be used to implement pagination where needed. 

Phone numbers will only match when you enter at least 7 digits, for privacy reasons. 

Example searching for '4' with a limit of 5 

```
postgres=> select * from tag_search('4',5);
-[ RECORD 1 ]---+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
send_id_matches | [{"send_id": 4, "tag_name": "brandon"}, {"send_id": 4, "tag_name": "bitches"}, {"send_id": 4, "tag_name": "2"}, {"send_id": 4, "tag_name": "beezy"}, {"send_id": 4, "tag_name": "God"}]
tag_matches     | [{"send_id": 10, "tag_name": "4"}, {"send_id": 112, "tag_name": "42"}, {"send_id": 1534, "tag_name": "420"}, {"send_id": 3068, "tag_name": "42069"}, {"send_id": 4127, "tag_name": "4tune"}]
phone_matches   | []
```

Example searching for beginning of my test number:

```
postgres=> select * from tag_search('1291622');
-[ RECORD 1 ]---+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
send_id_matches | []
tag_matches     | []
phone_matches   | [{"phone": "12916221446844", "send_id": 4, "tag_name": "brandon"}, {"phone": "12916221446844", "send_id": 4, "tag_name": "bitches"}, {"phone": "12916221446844", "send_id": 4, "tag_name": "2"}, {"phone": "12916221446844", "send_id": 4, "tag_name": "beezy"}, {"phone": "12916221446844", "send_id": 4, "tag_name": "God"}]

```

Example searching for specific tag:

```
postgres=> select * from tag_search('ethen');
-[ RECORD 1 ]---+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
send_id_matches | []
tag_matches     | [{"send_id": 2, "tag_name": "ethen", "avatar_url": "https://fjswgwdweohwejbrmiil.supabase.co/storage/v1/object/public/avatars/743d79cf-f861-4619-b7be-c46f70dc8b68/1712459659653.jpeg"}]
phone_matches   | []
```

I limited to 5 results on the frontend for now until pagination is figured out and the new screens implemented

