### PR TITLE
refactor: use send_revenues_safe_receives table to validate tag purchases

### DIFF
--- a/apps/distributor/src/distributor.test.ts
+++ b/apps/distributor/src/distributor.test.ts
@@ -205,7 +205,7 @@ describe('Distributor Worker', () => {
     }))
 
     const logger = pino({
-      level: 'debug',
+      level: 'silent',
     })
     const distributor = new DistributorWorker(logger, false)
     await distributor.calculateDistribution('4')

--- a/packages/app/utils/hexToPgBase16.test.ts
+++ b/packages/app/utils/hexToPgBase16.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from '@jest/globals'
+import { hexToPgBase16 } from './hexToPgBase16'
+
+describe('test hexToPgBase16', () => {
+  it('test hexToPgBase16', () => {
+    // Testing edge cases
+    expect(hexToPgBase16('0x')).toBe('\\x') // empty string
+    expect(hexToPgBase16('0x12')).toBe('\\x12') // single character
+    expect(hexToPgBase16('0x123')).toBe('\\x123') // two characters
+    expect(hexToPgBase16('0x1234')).toBe('\\x1234') // three characters
+    expect(hexToPgBase16('0x12345')).toBe('\\x12345') // four characters
+    expect(hexToPgBase16('0x123456')).toBe('\\x123456') // five characters
+    expect(hexToPgBase16('0x1234567')).toBe('\\x1234567') // six characters
+    expect(hexToPgBase16('0x12345678')).toBe('\\x12345678') // seven characters
+    expect(hexToPgBase16('0x123456789')).toBe('\\x123456789') // eight characters
+    expect(hexToPgBase16('0x1234567890')).toBe('\\x1234567890') // nine characters
+
+    // @ts-expect-error Testing with null or empty string
+    expect(() => hexToPgBase16('')).toThrow('Hex string must start with 0x')
+  })
+})

--- a/packages/app/utils/hexToPgBase16.ts
+++ b/packages/app/utils/hexToPgBase16.ts
@@ -1,0 +1,12 @@
+import { isHex } from 'viem'
+import { assert } from './assert'
+
+/**
+ * Converts a hex string to a Postgres base16 string
+ * @param str
+ * @returns 0x-prefixed hex string
+ */
+export function hexToPgBase16(str: `0x${string}`): `\\x${string}` {
+  assert(isHex(str), 'Hex string must start with 0x')
+  return `\\x${str.slice(2)}`
+}

--- a/packages/app/utils/pgBase16ToHex.test.ts
+++ b/packages/app/utils/pgBase16ToHex.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from '@jest/globals'
+import { pgBase16ToHex } from './pgBase16ToHex'
+
+describe('test pgBase16ToHex', () => {
+  it('test pgBase16ToHex', () => {
+    // Testing with default parameters
+    expect(pgBase16ToHex('\\x01020304')).toBe('0x01020304')
+
+    // Testing edge cases
+    expect(pgBase16ToHex('\\x00')).toBe('0x00') // empty string
+    expect(pgBase16ToHex('\\x')).toBe('0x') // empty string
+    expect(pgBase16ToHex('\\x01')).toBe('0x01') // single character
+    expect(pgBase16ToHex('\\x0102')).toBe('0x0102') // two characters
+    expect(pgBase16ToHex('\\x010203')).toBe('0x010203') // three characters
+    expect(pgBase16ToHex('\\x0102030405')).toBe('0x0102030405') // four characters
+    expect(pgBase16ToHex('\\x010203040506')).toBe('0x010203040506') // five characters
+    expect(pgBase16ToHex('\\x01020304050607')).toBe('0x01020304050607') // six characters
+    expect(pgBase16ToHex('\\x0102030405060708')).toBe('0x0102030405060708') // seven characters
+    expect(pgBase16ToHex('\\x010203040506070809')).toBe('0x010203040506070809') // eight characters
+    expect(pgBase16ToHex('\\x0102030405060708090a')).toBe('0x0102030405060708090a') // nine characters
+    expect(pgBase16ToHex('\\x0102030405060708090a0b0c')).toBe('0x0102030405060708090a0b0c') // ten characters
+
+    // @ts-expect-error Testing with null or empty string
+    expect(() => pgBase16ToHex('')).toThrow('Hex string must start with \\x')
+  })
+})

--- a/packages/app/utils/pgBase16ToHex.ts
+++ b/packages/app/utils/pgBase16ToHex.ts
@@ -1,0 +1,11 @@
+import { assert } from './assert'
+
+/**
+ * Converts a Postgres base16 string to a hex string
+ * @param str
+ * @returns 0x-prefixed hex string
+ */
+export function pgBase16ToHex(str: `\\x${string}`): `0x${string}` {
+  assert(str.startsWith('\\x'), 'Hex string must start with \\x')
+  return `0x${str.slice(2)}`
+}

--- a/supabase/migrations/20240424041809_add_send_revenues_safe_receives_rls_select_policy.sql
+++ b/supabase/migrations/20240424041809_add_send_revenues_safe_receives_rls_select_policy.sql
@@ -1,0 +1,8 @@
+create policy "Send revenues safe receives can be read by the user who created it"
+on "public"."send_revenues_safe_receives"
+as permissive
+for select
+to public
+using (((lower(concat('0x', encode(sender, 'hex'::text))))::citext = ( SELECT chain_addresses.address
+   FROM chain_addresses
+  WHERE (chain_addresses.user_id = ( SELECT auth.uid() AS uid)))));


### PR DESCRIPTION
- Use the send_revenues_safe_receives table to validate tag purchases instead of fetching event logs from the blockchain
- Add hexToPgBase16 and pgBase16ToHex utility functions for converting between hex and Postgres base16 formats
- Update useSenderSafeReceivedEvents hook to fetch data from send_revenues_safe_receives table
- Modify lookupSafeReceivedEvent function to use the send_revenues_safe_receives data for validation
- Add tests for hexToPgBase16 and pgBase16ToHex utility functions
- Add test case to ensure duplicate receipt hashes do not confirm tags