### PR TITLE
shovel: add send_account_signing_key_added

### DIFF
--- a/.snaplet/snaplet-client.d.ts
+++ b/.snaplet/snaplet-client.d.ts
@@ -227,6 +227,24 @@ type Override = {
       webauthn_credentials?: string;
     };
   }
+  send_account_signing_key_added?: {
+    name?: string;
+    fields?: {
+      chain_id?: string;
+      log_addr?: string;
+      block_time?: string;
+      tx_hash?: string;
+      account?: string;
+      key_slot?: string;
+      key?: string;
+      ig_name?: string;
+      src_name?: string;
+      block_num?: string;
+      tx_idx?: string;
+      log_idx?: string;
+      abi_idx?: string;
+    };
+  }
   send_account_transfers?: {
     name?: string;
     fields?: {
@@ -550,6 +568,15 @@ export interface Fingerprint {
     createdAt?: FingerprintDateField;
     account?: FingerprintRelationField;
     credential?: FingerprintRelationField;
+  }
+  sendAccountSigningKeyAddeds?: {
+    chainId?: FingerprintNumberField;
+    blockTime?: FingerprintNumberField;
+    keySlot?: FingerprintNumberField;
+    blockNum?: FingerprintNumberField;
+    txIdx?: FingerprintNumberField;
+    logIdx?: FingerprintNumberField;
+    abiIdx?: FingerprintNumberField;
   }
   sendAccountTransfers?: {
     id?: FingerprintNumberField;

--- a/.snaplet/snaplet.d.ts
+++ b/.snaplet/snaplet.d.ts
@@ -310,6 +310,21 @@ interface Table_public_send_account_credentials {
   key_slot: number;
   created_at: string | null;
 }
+interface Table_public_send_account_signing_key_added {
+  chain_id: number;
+  log_addr: string;
+  block_time: number;
+  tx_hash: string;
+  account: string;
+  key_slot: number;
+  key: string;
+  ig_name: string;
+  src_name: string;
+  block_num: number;
+  tx_idx: number;
+  log_idx: number;
+  abi_idx: number;
+}
 interface Table_public_send_account_transfers {
   id: number;
   chain_id: number | null;
@@ -550,6 +565,7 @@ interface Schema_public {
   referrals: Table_public_referrals;
   send_account_created: Table_public_send_account_created;
   send_account_credentials: Table_public_send_account_credentials;
+  send_account_signing_key_added: Table_public_send_account_signing_key_added;
   send_account_transfers: Table_public_send_account_transfers;
   send_accounts: Table_public_send_accounts;
   send_liquidity_pools: Table_public_send_liquidity_pools;

--- a/packages/shovel/etc/config.json
+++ b/packages/shovel/etc/config.json
@@ -371,6 +371,97 @@
           "start": "$BASE_BLOCK_START"
         }
       ]
+    },
+    {
+      "name": "send_account_signing_key_added",
+      "enabled": true,
+      "block": [
+        {
+          "name": "chain_id",
+          "column": "chain_id"
+        },
+        {
+          "name": "block_time",
+          "column": "block_time"
+        },
+        {
+          "name": "tx_hash",
+          "column": "tx_hash"
+        },
+        {
+          "name": "log_addr",
+          "column": "log_addr",
+          "filter_op": "contains",
+          "filter_ref": {
+            "integration": "send_account_created",
+            "column": "account"
+          }
+        }
+      ],
+      "event": {
+        "type": "event",
+        "anonymous": false,
+        "inputs": [
+          {
+            "name": "account",
+            "type": "address",
+            "indexed": true,
+            "column": "account"
+          },
+          {
+            "name": "keySlot",
+            "type": "uint8",
+            "indexed": false,
+            "column": "key_slot"
+          },
+          {
+            "name": "key",
+            "type": "bytes32[2]",
+            "indexed": false,
+            "column": "key"
+          }
+        ],
+        "name": "SigningKeyAdded"
+      },
+      "table": {
+        "name": "send_account_signing_key_added",
+        "columns": [
+          {
+            "name": "chain_id",
+            "type": "numeric"
+          },
+          {
+            "name": "log_addr",
+            "type": "bytea"
+          },
+          {
+            "name": "block_time",
+            "type": "numeric"
+          },
+          {
+            "name": "tx_hash",
+            "type": "bytea"
+          },
+          {
+            "name": "account",
+            "type": "bytea"
+          },
+          {
+            "name": "key_slot",
+            "type": "smallint"
+          },
+          {
+            "name": "key",
+            "type": "bytea"
+          }
+        ]
+      },
+      "sources": [
+        {
+          "name": "base_logs",
+          "start": "$BASE_BLOCK_START"
+        }
+      ]
     }
   ]
 }

--- a/packages/shovel/src/index.ts
+++ b/packages/shovel/src/index.ts
@@ -6,6 +6,7 @@ import {
   // sendAccountTransactionsIntegration,
   sendTokenTransfersIntegration,
   sendRevenuesSafeReceives,
+  sendAccountSigningKeyAdded,
 } from './integrations'
 
 // baseSrcBlockHeaders is to be used for integrations that require block headers
@@ -43,6 +44,10 @@ export const integrations: Integration[] = [
   },
   {
     ...sendRevenuesSafeReceives,
+    sources: [{ name: baseSrcLogs.name, start: '$BASE_BLOCK_START' }],
+  },
+  {
+    ...sendAccountSigningKeyAdded,
     sources: [{ name: baseSrcLogs.name, start: '$BASE_BLOCK_START' }],
   },
   // @todo split this into two integrations, one for Receive and one for UserOperationEvent

--- a/packages/shovel/src/integrations/index.ts
+++ b/packages/shovel/src/integrations/index.ts
@@ -3,3 +3,4 @@ export { integration as sendAccountTransfersIntegration } from './send-account-t
 export { integration as sendAccountTransactionsIntegration } from './send-account-transactions'
 export { integration as sendTokenTransfersIntegration } from './send-token-transfers'
 export { integration as sendRevenuesSafeReceives } from './send-revenues-safe-receives'
+export { integration as sendAccountSigningKeyAdded } from './send-account-signing-key-added'

--- a/packages/shovel/src/integrations/send-account-created.ts
+++ b/packages/shovel/src/integrations/send-account-created.ts
@@ -6,7 +6,6 @@ import type {
   Table,
 } from '@indexsupply/shovel-config'
 import { sendAccountFactoryAddress } from '@my/wagmi'
-import { ENTRYPOINT_ADDRESS_V07 } from 'permissionless'
 
 export const sendAcctFactoryTable: Table = {
   name: 'send_account_created',

--- a/packages/shovel/src/integrations/send-account-signing-key-added.ts
+++ b/packages/shovel/src/integrations/send-account-signing-key-added.ts
@@ -1,0 +1,56 @@
+import type { BlockData, Column, Integration, Table } from '@indexsupply/shovel-config'
+import { sendAccountFactorySenderFilterRef } from './send-account-created'
+
+export const table: Table = {
+  name: 'send_account_signing_key_added',
+  columns: [
+    { name: 'chain_id', type: 'numeric' },
+    { name: 'log_addr', type: 'bytea' },
+    { name: 'block_time', type: 'numeric' },
+    { name: 'tx_hash', type: 'bytea' },
+    { name: 'account', type: 'bytea' },
+    { name: 'key_slot', type: 'smallint' },
+    { name: 'key', type: 'bytea' },
+  ] as Column[],
+} as const
+
+export const integration: Omit<Integration, 'sources'> = {
+  name: 'send_account_signing_key_added',
+  enabled: true,
+  block: [
+    {
+      name: 'chain_id',
+      column: 'chain_id',
+    },
+    {
+      name: 'block_time',
+      column: 'block_time',
+    },
+    {
+      name: 'tx_hash',
+      column: 'tx_hash',
+    },
+    {
+      name: 'log_addr',
+      column: 'log_addr',
+      filter_op: 'contains',
+      filter_ref: sendAccountFactorySenderFilterRef,
+    },
+  ] as BlockData[],
+  event: {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'account',
+        type: 'address',
+        indexed: true,
+        column: 'account',
+      },
+      { name: 'keySlot', type: 'uint8', indexed: false, column: 'key_slot' },
+      { name: 'key', type: 'bytes32[2]', indexed: false, column: 'key' },
+    ],
+    name: 'SigningKeyAdded',
+  },
+  table: table,
+} as const

--- a/packages/shovel/test/__snapshots__/index.test.ts.snap
+++ b/packages/shovel/test/__snapshots__/index.test.ts.snap
@@ -358,6 +358,97 @@ exports[`shovel config 1`] = `
         "name": "send_revenues_safe_receives",
       },
     },
+    {
+      "block": [
+        {
+          "column": "chain_id",
+          "name": "chain_id",
+        },
+        {
+          "column": "block_time",
+          "name": "block_time",
+        },
+        {
+          "column": "tx_hash",
+          "name": "tx_hash",
+        },
+        {
+          "column": "log_addr",
+          "filter_op": "contains",
+          "filter_ref": {
+            "column": "account",
+            "integration": "send_account_created",
+          },
+          "name": "log_addr",
+        },
+      ],
+      "enabled": true,
+      "event": {
+        "anonymous": false,
+        "inputs": [
+          {
+            "column": "account",
+            "indexed": true,
+            "name": "account",
+            "type": "address",
+          },
+          {
+            "column": "key_slot",
+            "indexed": false,
+            "name": "keySlot",
+            "type": "uint8",
+          },
+          {
+            "column": "key",
+            "indexed": false,
+            "name": "key",
+            "type": "bytes32[2]",
+          },
+        ],
+        "name": "SigningKeyAdded",
+        "type": "event",
+      },
+      "name": "send_account_signing_key_added",
+      "sources": [
+        {
+          "name": "base_logs",
+          "start": "$BASE_BLOCK_START",
+        },
+      ],
+      "table": {
+        "columns": [
+          {
+            "name": "chain_id",
+            "type": "numeric",
+          },
+          {
+            "name": "log_addr",
+            "type": "bytea",
+          },
+          {
+            "name": "block_time",
+            "type": "numeric",
+          },
+          {
+            "name": "tx_hash",
+            "type": "bytea",
+          },
+          {
+            "name": "account",
+            "type": "bytea",
+          },
+          {
+            "name": "key_slot",
+            "type": "smallint",
+          },
+          {
+            "name": "key",
+            "type": "bytea",
+          },
+        ],
+        "name": "send_account_signing_key_added",
+      },
+    },
   ],
   "pg_url": "$DATABASE_URL",
   "sources": [

--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -411,6 +411,54 @@ export type Database = {
           },
         ]
       }
+      send_account_signing_key_added: {
+        Row: {
+          abi_idx: number
+          account: string
+          block_num: number
+          block_time: number
+          chain_id: number
+          ig_name: string
+          key: string
+          key_slot: number
+          log_addr: string
+          log_idx: number
+          src_name: string
+          tx_hash: string
+          tx_idx: number
+        }
+        Insert: {
+          abi_idx: number
+          account: string
+          block_num: number
+          block_time: number
+          chain_id: number
+          ig_name: string
+          key: string
+          key_slot: number
+          log_addr: string
+          log_idx: number
+          src_name: string
+          tx_hash: string
+          tx_idx: number
+        }
+        Update: {
+          abi_idx?: number
+          account?: string
+          block_num?: number
+          block_time?: number
+          chain_id?: number
+          ig_name?: string
+          key?: string
+          key_slot?: number
+          log_addr?: string
+          log_idx?: number
+          src_name?: string
+          tx_hash?: string
+          tx_idx?: number
+        }
+        Relationships: []
+      }
       send_account_transfers: {
         Row: {
           abi_idx: number | null

--- a/supabase/migrations/20240425030525_add_send_account_signing_key_added.sql
+++ b/supabase/migrations/20240425030525_add_send_account_signing_key_added.sql
@@ -1,0 +1,28 @@
+create table "public"."send_account_signing_key_added"
+(
+    "chain_id"   numeric  not null,
+    "log_addr"   bytea    not null,
+    "block_time" numeric  not null,
+    "tx_hash"    bytea    not null,
+    "account"    bytea    not null,
+    "key_slot"   smallint not null,
+    "key"        bytea    not null,
+    "ig_name"    text     not null,
+    "src_name"   text     not null,
+    "block_num"  numeric  not null,
+    "tx_idx"     integer  not null,
+    "log_idx"    integer  not null,
+    "abi_idx"    smallint not null
+);
+
+create unique index u_send_account_signing_key_added on public.send_account_signing_key_added using btree (ig_name, src_name, block_num, tx_idx, log_idx, abi_idx);
+
+create index send_account_signing_key_added_account_idx on public.send_account_signing_key_added using btree (account);
+
+alter table "public"."send_account_signing_key_added"
+    enable row level security;
+
+create policy "Send account signing key added can be read by the user who created it" on "public"."send_account_signing_key_added" as permissive for select to public using (
+    account in ( select decode(substring(address, 3), 'hex')
+                 from "public"."send_accounts"
+                 where (user_id = ( select auth.uid() as uid )) ));


### PR DESCRIPTION
Starts the backend integration for managing keys and eventually adding backup signers to your send account.