### PR TITLE
contracts: add UpdateTokenPaymasterCachedPriceScript

### DIFF
--- a/apps/aabundler/README.md
+++ b/apps/aabundler/README.md
@@ -41,3 +41,20 @@ The bundler is configured via a JSON file or command line arguments. Below is an
   "beneficiary": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
 }
 ```
+
+### Developer mode
+
+You can run the bundler in developer mode by running the following commands from the root of the bundler repo.
+
+```bash
+cd $FULLPATH/eth-infinitism-bundler/packages/utils/
+yarn run tsc
+
+cd $FULLPATH/eth-infinitism-bundler/packages/bundler/
+
+DEBUG="aa.*" yarn run ts-node ./src/exec.ts \
+
+--port 3030 \
+
+--config $FULLPATH/etc/aabundler-nodocker.config.json
+```

--- a/packages/app/features/account/sendtag/checkout/components/checkout-confirm-button.tsx
+++ b/packages/app/features/account/sendtag/checkout/components/checkout-confirm-button.tsx
@@ -204,7 +204,7 @@ export function ConfirmButton({
       assert(!!userOp, 'User op is required')
       await sendUserOp({ userOp })
     } catch (e) {
-      setError(e.message)
+      setError(e.message.split('.').at(0))
     }
   }
 

--- a/packages/app/utils/userop.ts
+++ b/packages/app/utils/userop.ts
@@ -122,7 +122,7 @@ export function generateChallenge({
   userOpHash,
   version = USEROP_VERSION,
   validUntil,
-}: { userOpHash: Hex; version?: number; validUntil }): {
+}: { userOpHash: Hex; version?: number; validUntil: number }): {
   challenge: Hex
   versionBytes: Uint8Array
   validUntilBytes: Uint8Array
@@ -195,10 +195,13 @@ export async function signUserOp({
   validUntil?: number
 }) {
   version = version ?? USEROP_VERSION
-  validUntil = validUntil ?? Math.floor((Date.now() + 1000 * 60) / 1000) // default 60 seconds
+  validUntil = validUntil ?? Math.floor((Date.now() + 1000 * 60) / 1000) // default 60 seconds (1 minute
   assert(version === USEROP_VERSION, 'version must be 1')
   assert(typeof validUntil === 'number', 'validUntil must be a number')
-  assert(validUntil > Math.floor(Date.now() / 1000), 'validUntil must be in the future')
+  assert(
+    validUntil === 0 || validUntil > Math.floor(Date.now() / 1000), // 0 means valid forever
+    'validUntil must be in the future'
+  )
   const { challenge, versionBytes, validUntilBytes } = generateChallenge({
     userOpHash,
     version,

--- a/packages/contracts/.gitignore
+++ b/packages/contracts/.gitignore
@@ -8,5 +8,6 @@ out/
 /broadcast/CreateSendDistributionTranche.s.sol/
 /broadcast/CreateSendSnapshot.s.sol/
 /broadcast/DeployTestnetSendToken.s.sol/
+/broadcast/UpdateTokenPaymasterCachedPrice.s.sol/
 /broadcast/**/run-*.json
 !/broadcast/**/run-latest.json

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -121,6 +121,17 @@ forge script ./script/DeploySendMerkleDrop.s.sol:DeploySendMerkleDropScript \
   --keystores ~/.foundry/keystores/send_deployer
 ```
 
+#### Updating Token Paymaster Cached Price
+
+```shell
+PAYMASTER=0x7e84448C1c94978f480D1895E6566C31c32fb136 \
+forge script ./script/UpdateTokenPaymasterCachedPrice.s.sol:UpdateTokenPaymasterCachedPriceScript \
+  -vvv \
+  --rpc-url base-sepolia \
+  --sender 0xfB00d9CDA6DaD99994849d7C66Fa2631f280F64f \
+  --keystores ~/.foundry/keystores/send_core_dev
+```
+
 #### Creating a Distribution Tranche
 
 ```shell

--- a/packages/contracts/script/UpdateTokenPaymasterCachedPrice.s.sol
+++ b/packages/contracts/script/UpdateTokenPaymasterCachedPrice.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import "../src/TokenPaymaster.sol";
+
+contract UpdateTokenPaymasterCachedPriceScript is Script {
+    function run() public {
+        address addr = vm.envAddress("PAYMASTER");
+
+        require(addr != address(0), "PAYMASTER env variable not set");
+
+        TokenPaymaster paymaster = TokenPaymaster(payable(addr));
+
+        vm.startBroadcast();
+        paymaster.updateCachedPrice(true);
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
This was discovered during testnet when the bundler validates the validUntil for both the sender and the paymaster (if set).

The token paymaster sets the valid until to the last price update + max age. Perhaps, this needs to be automated if the postOp does not update during normal operations.