### PR TITLE
update playwright tests

### DIFF
--- a/packages/app/features/send/components/SendSearch.tsx
+++ b/packages/app/features/send/components/SendSearch.tsx
@@ -260,7 +260,7 @@ export function Search() {
   const { resolvedTheme } = useThemeSetting()
   const iconColor = resolvedTheme?.startsWith('dark') ? '$olive' : '$black'
   return (
-    <View position="relative">
+    <View position="relative" testID="sendSearchContainer">
       <FormProvider {...form}>
         <SchemaForm
           form={form}

--- a/packages/playwright/tests/activity.onboarded.spec.ts
+++ b/packages/playwright/tests/activity.onboarded.spec.ts
@@ -22,7 +22,7 @@ test('can visit activity page', async ({ page }) => {
   await expect(activityHeading(page)).toBeVisible()
 })
 
-test.skip('can search on activity page', async ({ page, context }) => {
+test('can search on activity page', async ({ page, context }) => {
   await page.goto('/activity')
   log('beforeEach', `url=${page.url()}`)
   const testTags = ['dob_spud89665', 'down_coke9222', 'few_down65006']

--- a/packages/playwright/tests/profile.onboarded.spec.ts
+++ b/packages/playwright/tests/profile.onboarded.spec.ts
@@ -14,7 +14,7 @@ test.beforeAll(async () => {
   log = debug(`test:profile:logged-in:${test.info().workerIndex}`)
 })
 
-test.skip('can visit other user profile', async ({ page, seed }) => {
+test('can visit other user profile', async ({ page, seed }) => {
   const plan = await seed.users([userOnboarded])
   const tag = plan.tags[0]
   const profile = plan.profiles[0]
@@ -26,7 +26,7 @@ test.skip('can visit other user profile', async ({ page, seed }) => {
   await expect(profilePage.sendButton).toBeVisible()
   await expect(profilePage.requestButton).toBeVisible()
   await profilePage.sendButton.click()
-  await expect(page.getByTestId('sendDialogContainer')).toBeVisible()
+  await expect(page.getByTestId('sendSearchContainer')).toBeVisible()
 })
 
 test('can visit my own profile', async ({


### PR DESCRIPTION
I enabled `activity.onboarded` 'can search on activity page' because it's passing locally even though I didn't change anything in the test itself. If there was another reason it was skipped, just let me know and I can update that. 