### PR TITLE
add SendtagCheckout contracts

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -25,7 +25,8 @@
     "dev:anvil-add-token-paymaster-fixtures": "bun run ./script/anvil-add-token-paymaster-fixtures.ts",
     "dev:anvil-add-send-check-fixtures": "bun run ./script/anvil-add-send-check-fixtures.ts",
     "dev:anvil-token-paymaster-deposit": "bun run ./script/anvil-token-paymaster-deposit.ts",
-    "dev:anvil-deploy-fjord-send-verifier-fixtures": "bun run ./script/anvil-deploy-fjord-send-verifier-fixtures.ts"
+    "dev:anvil-deploy-fjord-send-verifier-fixtures": "bun run ./script/anvil-deploy-fjord-send-verifier-fixtures.ts",
+    "dev:anvil-add-sendtag-checkout-fixtures": "bun run ./script/anvil-add-sendtag-checkout-fixtures.ts"
   },
   "devDependencies": {
     "@my/supabase": "workspace:*",

--- a/packages/contracts/script/DeploySendtagCheckout.s.sol
+++ b/packages/contracts/script/DeploySendtagCheckout.s.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+import {Helper} from "../src/Helper.sol";
+import {SendtagCheckout} from "../src/SendtagCheckout.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @dev forge script ./script/DeploySendtagCheckout.s.sol:DeploySendtagCheckoutScript
+contract DeploySendtagCheckoutScript is Script, Helper {
+    function setUp() public {
+        this.labels();
+    }
+
+    function run() external returns (SendtagCheckout) {
+        address multisig = vm.envAddress("MULTISIG");
+        IERC20 token = IERC20(vm.envAddress("TOKEN"));
+        require(multisig != address(0), "MULTISIG not set");
+        require(token != IERC20(address(0)), "TOKEN not set");
+        return this.deploy(multisig, token);
+    }
+
+    function deploy(address multisig, IERC20 token) external returns (SendtagCheckout) {
+        vm.startBroadcast();
+        SendtagCheckout sendtagCheckout = new SendtagCheckout{salt: 0}(multisig, token);
+        vm.stopBroadcast();
+        return sendtagCheckout;
+    }
+}

--- a/packages/contracts/script/anvil-add-sendtag-checkout-fixtures.ts
+++ b/packages/contracts/script/anvil-add-sendtag-checkout-fixtures.ts
@@ -1,0 +1,36 @@
+import 'zx/globals'
+$.verbose = true
+
+/**
+ * This script is used to deploy the DeploySendtagCheckout
+ */
+
+const RPC_URL = 'http://127.0.0.1:8546'
+void (async function main() {
+  console.log(chalk.blue('Enable auto-mining...'))
+  await $`cast rpc --rpc-url ${RPC_URL} evm_setAutomine true`
+
+  $.env.MULTISIG = '0x71fa02bb11e4b119bEDbeeD2f119F62048245301'
+  $.env.TOKEN = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+
+  console.log(
+    `${chalk.blue('Deploying DeploySendtagCheckout contract...')}
+MULTISIG=${$.env.MULTISIG}\t\thttps://basescan.org/address/${$.env.MULTISIG}
+TOKEN=${$.env.TOKEN}\t\thttps://basescan.org/address/${$.env.TOKEN}
+`
+  )
+  await $`forge script ./script/DeploySendtagCheckout.s.sol:DeploySendtagCheckoutScript \
+              -vvvv \
+              --rpc-url ${RPC_URL} \
+              --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
+              --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+              --broadcast`
+
+  console.log(chalk.blue('Disable auto-mining...'))
+  await $`cast rpc --rpc-url ${RPC_URL} evm_setAutomine false`
+
+  console.log(chalk.blue(`Re-enable interval mining... ${$.env.ANVIL_BLOCK_TIME ?? '2'}`))
+  await $`cast rpc --rpc-url ${RPC_URL} evm_setIntervalMining ${$.env.ANVIL_BLOCK_TIME ?? '2'}` // mimics Tiltfile default
+
+  console.log(chalk.green('Done!'))
+})()

--- a/packages/contracts/src/Helper.sol
+++ b/packages/contracts/src/Helper.sol
@@ -20,23 +20,24 @@ abstract contract Helper is Script {
     /**
      * Send: Treasury
      * https://etherscan.io/address/0x4bB2f4c771ccB60723a78a974a2537AD339071c7
-     *
      */
     address constant SEND_TREASURY_SAFE = 0x05CEa6C36f3a44944A4F4bA39B1820677AcB97EE;
     /**
+     * Send: Revenue
+     * https://basescan.io/address/0x71fa02bb11e4b119bEDbeeD2f119F62048245301
+     */
+    address constant SEND_REVENUE_SAFE = 0x71fa02bb11e4b119bEDbeeD2f119F62048245301;
+    /**
      * Send: Airdrops
      * https://etherscan.io/address/0x6204Bc0662ccd8a9A762d59fe7906733f251E3b7
-     *
      */
     address constant SEND_AIRDROPS_SAFE = 0x077c4E5983e5c495599C1Eb5c1511A52C538eB50;
     /**
-     *
      * Account-Abstraction (EIP-4337) v0.6.0 singleton EntryPoint implementation.
      * https://basescan.org/address/0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
      */
     address constant AA_ENTRY_POINT_V0_6 = 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789;
     /**
-     *
      * Account-Abstraction (EIP-4337) v0.7.0 singleton EntryPoint implementation.
      * https://basescan.org/address/0x0000000071727De22E5E9d8BAf0edAc6f37da032
      */
@@ -47,6 +48,7 @@ abstract contract Helper is Script {
         vm.label(OG_SEND_DEPLOYER, "OG_SEND_DEPLOYER");
         vm.label(BASE_SEND_MVP_DEPLOYER, "BASE_SEND_MVP_DEPLOYER");
         vm.label(SEND_TREASURY_SAFE, "SEND_TREASURY_SAFE");
+        vm.label(SEND_REVENUE_SAFE, "SEND_REVENUE_SAFE");
         vm.label(SEND_AIRDROPS_SAFE, "SEND_AIRDROPS_SAFE");
         vm.label(AA_ENTRY_POINT_V0_6, "AA_ENTRY_POINT_V0_6");
         vm.label(AA_ENTRY_POINT_V0_7, "AA_ENTRY_POINT_V0_7");

--- a/packages/contracts/src/SendtagCheckout.sol
+++ b/packages/contracts/src/SendtagCheckout.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.23;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @title SendtagCheckout: A contract for handling Sendtag checkouts.
+/// @author Big Boss
+/// @notice This contract handles the checkout process for Sendtags. It handles the ERC20 token payments to the Send Multisig and remits of funds to a referrer.
+/// @dev /FYSI
+contract SendtagCheckout is Ownable {
+    /// @notice The token used for payments.
+    IERC20 public immutable token;
+
+    /// @notice The address of the Multisig to receive the payments.
+    address public immutable multisig;
+
+    /// @notice When false, the contract is paused and checkouts are not allowed.
+    bool public open;
+
+    /// @notice The event emitted when a referrer is paid.
+    event ReferralBonus(address indexed referrer, address referred, uint256 amount);
+
+    /// @notice The event emitted when the contract is toggled.
+    event Toggled(bool open);
+
+    constructor(address _sendRevenuesMultisig, IERC20 _token) Ownable(msg.sender) {
+        require(_sendRevenuesMultisig != address(0), "Invalid Send Multisig address");
+        require(address(_token) != address(0), "Invalid token address");
+        token = _token;
+        multisig = _sendRevenuesMultisig;
+        open = true;
+        emit Toggled(open);
+    }
+
+    /// @notice Sends the funds to the Send Multisig and remits funds to a referrer.
+    /// @param amount The amount of tokens to pay.
+    /// @param referrer The address of the referrer.
+    /// @param bonus The amount to pay to the referrer.
+    /// @dev Does not check if amount is valid or not. That is done offchain.
+    function checkout(uint256 amount, address referrer, uint256 bonus) external {
+        require(open, "Not open");
+        require(amount > 0, "Invalid amount");
+
+        // First, collect the amount to this contract
+        SafeERC20.safeTransferFrom(token, msg.sender, address(this), amount);
+
+        // Then, pay the referrer...
+        if (bonus > 0) {
+            require(referrer != address(0), "Invalid referrer address");
+            require(bonus <= amount, "Invalid referrer bonus");
+            SafeERC20.safeTransfer(token, referrer, bonus);
+            emit ReferralBonus(referrer, msg.sender, bonus);
+        }
+
+        // Finally, send the funds to the Send Multisig
+        SafeERC20.safeTransfer(token, multisig, amount - bonus);
+    }
+
+    /// @notice Toggle the contract.
+    function toggle() external onlyOwner {
+        open = !open;
+        emit Toggled(open);
+    }
+
+    /// @notice Withdraws fund from the contract.
+    /// @param _token The token to withdraw.
+    /// @param amount The amount to withdraw.
+    function withdrawToken(IERC20 _token, uint256 amount) external onlyOwner {
+        SafeERC20.safeTransfer(_token, msg.sender, amount);
+    }
+
+    /// @notice Withdraws ETH from the contract.
+    function withdrawETH() external onlyOwner {
+        payable(msg.sender).transfer(address(this).balance);
+    }
+}

--- a/packages/contracts/test/DeploySendtagCheckout.t.sol
+++ b/packages/contracts/test/DeploySendtagCheckout.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {Helper} from "../src/Helper.sol";
+import {DeploySendtagCheckoutScript} from "../script/DeploySendtagCheckout.s.sol";
+import {SendtagCheckout} from "../src/SendtagCheckout.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract DeploySendtagCheckoutTest is Test, Helper {
+    function setUp() public {
+        this.labels();
+    }
+
+    function testItRuns() public {
+        DeploySendtagCheckoutScript script = new DeploySendtagCheckoutScript();
+        address multisig = address(SEND_REVENUE_SAFE);
+        address token = address(0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913);
+        vm.setEnv("MULTISIG", vm.toString(SEND_REVENUE_SAFE));
+        vm.setEnv("TOKEN", vm.toString(token));
+        SendtagCheckout sc = script.run();
+        assertEq(sc.multisig(), multisig);
+        assertEq(address(sc.token()), token);
+    }
+}

--- a/packages/contracts/test/SendtagCheckout.t.sol
+++ b/packages/contracts/test/SendtagCheckout.t.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.23;
+
+import {Test} from "forge-std/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import {SendtagCheckout} from "../src/SendtagCheckout.sol";
+
+contract Tendies is ERC20 {
+    constructor() ERC20("TENDIES", "TENDIES") {}
+
+    function mint(uint256 amount) public {
+        _mint(msg.sender, amount);
+    }
+}
+
+contract SendtagCheckoutTest is Test {
+    SendtagCheckout checkout;
+    Tendies token;
+    address owner;
+    address multisig;
+
+    function setUp() public {
+        token = new Tendies();
+        multisig = address(0x1337);
+        owner = address(0xB055);
+        vm.startPrank(owner);
+        checkout = new SendtagCheckout(multisig, token);
+        vm.stopPrank();
+    }
+
+    /// @notice Test the checkout function with no referrer.
+    /// Bob wants a sendtag, he just found send.app and wants to send some money
+    function testFuzzCheckoutNoReferrer(uint256 amount) public {
+        vm.assume(amount > 0);
+        address sender = address(0xb0b);
+        vm.startPrank(sender);
+        token.mint(amount);
+        token.approve(address(checkout), amount);
+        checkout.checkout(amount, address(0), 0);
+        vm.stopPrank();
+        assertEq(token.balanceOf(multisig), amount);
+        assertEq(token.balanceOf(sender), 0);
+        assertEq(token.balanceOf(address(0)), 0);
+    }
+
+    /// @notice Test the checkout function with a referrer.
+    /// Bob wants a sendtag, he just found send.app because of his friend Alice and uses her referral code
+    function testFuzzCheckoutReferrer(uint256 amount, uint256 bonus) public {
+        vm.assume(amount > 0);
+        vm.assume(bonus <= amount);
+        address sender = address(0xb0b);
+        address referrer = address(0xa71ce);
+        vm.startPrank(sender);
+        token.mint(amount);
+        token.approve(address(checkout), amount);
+        if (bonus > 0) {
+            vm.expectEmit(true, true, true, true);
+            emit SendtagCheckout.ReferralBonus(referrer, sender, bonus);
+        }
+        checkout.checkout(amount, referrer, bonus);
+        vm.stopPrank();
+        assertEq(token.balanceOf(multisig), amount - bonus);
+        assertEq(token.balanceOf(sender), 0);
+        assertEq(token.balanceOf(referrer), bonus);
+    }
+
+    /// @notice Test the checkout function with a bonus and invalid referrer.
+    function testCheckoutInvalidReferrer(uint256 amount, uint256 bonus) public {
+        vm.assume(amount > 0);
+        vm.assume(bonus > 0);
+        vm.assume(bonus <= amount);
+        address sender = address(0xb0b);
+        vm.startPrank(sender);
+        token.mint(amount);
+        token.approve(address(checkout), amount);
+        vm.expectRevert("Invalid referrer address");
+        checkout.checkout(amount, address(0), bonus);
+        vm.stopPrank();
+    }
+
+    /// @notice Test the toggle function.
+    function testToggle() public {
+        assertTrue(checkout.open());
+        vm.startPrank(owner);
+        checkout.toggle();
+        vm.stopPrank();
+        assertFalse(checkout.open());
+
+        // cannot checkout now
+        address sender = address(0xb0b);
+        vm.startPrank(sender);
+        uint256 amount = 100;
+        token.mint(amount);
+        token.approve(address(checkout), amount);
+        vm.expectRevert("Not open");
+        checkout.checkout(amount, address(0), 0);
+        vm.stopPrank();
+
+        // non-owners cannot toggle
+        vm.startPrank(address(0x1337));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0x1337)));
+        checkout.toggle();
+        vm.stopPrank();
+
+        // can turn back on
+        vm.startPrank(owner);
+        checkout.toggle();
+        vm.stopPrank();
+        assertTrue(checkout.open());
+
+        // can checkout again
+        vm.startPrank(sender);
+        checkout.checkout(amount, address(0), 0);
+        vm.stopPrank();
+    }
+
+    function testWithdrawToken() public {
+        uint256 amount = 100;
+        vm.startPrank(address(0xb0b));
+        token.mint(amount);
+        token.transfer(address(checkout), amount);
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(address(checkout)), amount);
+
+        vm.prank(owner);
+        checkout.withdrawToken(token, amount);
+
+        assertEq(token.balanceOf(address(checkout)), 0);
+        assertEq(token.balanceOf(owner), amount);
+    }
+
+    function testWithdrawTokenUnauthorized() public {
+        uint256 amount = 100;
+        vm.startPrank(address(0xb0b));
+        token.mint(amount);
+        token.transfer(address(checkout), amount);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0xb0b)));
+        checkout.withdrawToken(token, amount);
+        vm.stopPrank();
+    }
+
+    function testWithdrawETH() public {
+        uint256 amount = 1 ether;
+        vm.deal(address(checkout), amount);
+
+        assertEq(address(checkout).balance, amount);
+
+        vm.prank(owner);
+        checkout.withdrawETH();
+
+        assertEq(address(checkout).balance, 0);
+        assertEq(owner.balance, amount);
+    }
+
+    function testWithdrawETHUnauthorized() public {
+        uint256 amount = 1 ether;
+        vm.deal(address(checkout), amount);
+
+        vm.prank(address(0xb0b));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0xb0b)));
+        checkout.withdrawETH();
+    }
+
+    function testWithdrawDifferentToken() public {
+        Tendies differentToken = new Tendies();
+        uint256 amount = 100;
+
+        vm.startPrank(address(0xb0b));
+        differentToken.mint(amount);
+        differentToken.transfer(address(checkout), amount);
+        vm.stopPrank();
+
+        assertEq(differentToken.balanceOf(address(checkout)), amount);
+
+        vm.prank(owner);
+        checkout.withdrawToken(IERC20(address(differentToken)), amount);
+
+        assertEq(differentToken.balanceOf(address(checkout)), 0);
+        assertEq(differentToken.balanceOf(owner), amount);
+    }
+}

--- a/packages/wagmi/src/generated.ts
+++ b/packages/wagmi/src/generated.ts
@@ -3190,6 +3190,155 @@ export const senderCreatorAbi = [
 ] as const
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// SendtagCheckout
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ */
+export const sendtagCheckoutAbi = [
+  {
+    type: 'constructor',
+    inputs: [
+      { name: '_sendRevenuesMultisig', internalType: 'address', type: 'address' },
+      { name: '_token', internalType: 'contract IERC20', type: 'address' },
+    ],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+      { name: 'referrer', internalType: 'address', type: 'address' },
+      { name: 'bonus', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'checkout',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'multisig',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'open',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'owner',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'renounceOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  { type: 'function', inputs: [], name: 'toggle', outputs: [], stateMutability: 'nonpayable' },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'token',
+    outputs: [{ name: '', internalType: 'contract IERC20', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'newOwner', internalType: 'address', type: 'address' }],
+    name: 'transferOwnership',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  { type: 'function', inputs: [], name: 'withdrawETH', outputs: [], stateMutability: 'nonpayable' },
+  {
+    type: 'function',
+    inputs: [
+      { name: '_token', internalType: 'contract IERC20', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'withdrawToken',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'previousOwner', internalType: 'address', type: 'address', indexed: true },
+      { name: 'newOwner', internalType: 'address', type: 'address', indexed: true },
+    ],
+    name: 'OwnershipTransferred',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      { name: 'referrer', internalType: 'address', type: 'address', indexed: true },
+      { name: 'referred', internalType: 'address', type: 'address', indexed: false },
+      { name: 'amount', internalType: 'uint256', type: 'uint256', indexed: false },
+    ],
+    name: 'ReferralBonus',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [{ name: 'open', internalType: 'bool', type: 'bool', indexed: false }],
+    name: 'Toggled',
+  },
+  {
+    type: 'error',
+    inputs: [{ name: 'target', internalType: 'address', type: 'address' }],
+    name: 'AddressEmptyCode',
+  },
+  {
+    type: 'error',
+    inputs: [{ name: 'account', internalType: 'address', type: 'address' }],
+    name: 'AddressInsufficientBalance',
+  },
+  { type: 'error', inputs: [], name: 'FailedInnerCall' },
+  {
+    type: 'error',
+    inputs: [{ name: 'owner', internalType: 'address', type: 'address' }],
+    name: 'OwnableInvalidOwner',
+  },
+  {
+    type: 'error',
+    inputs: [{ name: 'account', internalType: 'address', type: 'address' }],
+    name: 'OwnableUnauthorizedAccount',
+  },
+  {
+    type: 'error',
+    inputs: [{ name: 'token', internalType: 'address', type: 'address' }],
+    name: 'SafeERC20FailedOperation',
+  },
+] as const
+
+/**
+ *
+ */
+export const sendtagCheckoutAddress = {
+  845337: '0x3f14f917fB2DF7e0f3c6b06BB0Fa0522FBEA4Eec',
+} as const
+
+/**
+ *
+ */
+export const sendtagCheckoutConfig = {
+  address: sendtagCheckoutAddress,
+  abi: sendtagCheckoutAbi,
+} as const
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // TokenPaymaster
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -7294,6 +7443,253 @@ export const prepareWriteSenderCreator = /*#__PURE__*/ createSimulateContract({
 export const prepareWriteSenderCreatorCreateSender = /*#__PURE__*/ createSimulateContract({
   abi: senderCreatorAbi,
   functionName: 'createSender',
+})
+
+/**
+ * Wraps __{@link readContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__
+ *
+ *
+ */
+export const readSendtagCheckout = /*#__PURE__*/ createReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+})
+
+/**
+ * Wraps __{@link readContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"multisig"`
+ *
+ *
+ */
+export const readSendtagCheckoutMultisig = /*#__PURE__*/ createReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'multisig',
+})
+
+/**
+ * Wraps __{@link readContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"open"`
+ *
+ *
+ */
+export const readSendtagCheckoutOpen = /*#__PURE__*/ createReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'open',
+})
+
+/**
+ * Wraps __{@link readContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"owner"`
+ *
+ *
+ */
+export const readSendtagCheckoutOwner = /*#__PURE__*/ createReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'owner',
+})
+
+/**
+ * Wraps __{@link readContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"token"`
+ *
+ *
+ */
+export const readSendtagCheckoutToken = /*#__PURE__*/ createReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'token',
+})
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__
+ *
+ *
+ */
+export const writeSendtagCheckout = /*#__PURE__*/ createWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+})
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"checkout"`
+ *
+ *
+ */
+export const writeSendtagCheckoutCheckout = /*#__PURE__*/ createWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'checkout',
+})
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"renounceOwnership"`
+ *
+ *
+ */
+export const writeSendtagCheckoutRenounceOwnership = /*#__PURE__*/ createWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'renounceOwnership',
+})
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"toggle"`
+ *
+ *
+ */
+export const writeSendtagCheckoutToggle = /*#__PURE__*/ createWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'toggle',
+})
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"transferOwnership"`
+ *
+ *
+ */
+export const writeSendtagCheckoutTransferOwnership = /*#__PURE__*/ createWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'transferOwnership',
+})
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"withdrawETH"`
+ *
+ *
+ */
+export const writeSendtagCheckoutWithdrawEth = /*#__PURE__*/ createWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'withdrawETH',
+})
+
+/**
+ * Wraps __{@link writeContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"withdrawToken"`
+ *
+ *
+ */
+export const writeSendtagCheckoutWithdrawToken = /*#__PURE__*/ createWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'withdrawToken',
+})
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__
+ *
+ *
+ */
+export const prepareWriteSendtagCheckout = /*#__PURE__*/ createSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+})
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"checkout"`
+ *
+ *
+ */
+export const prepareWriteSendtagCheckoutCheckout = /*#__PURE__*/ createSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'checkout',
+})
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"renounceOwnership"`
+ *
+ *
+ */
+export const prepareWriteSendtagCheckoutRenounceOwnership = /*#__PURE__*/ createSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'renounceOwnership',
+})
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"toggle"`
+ *
+ *
+ */
+export const prepareWriteSendtagCheckoutToggle = /*#__PURE__*/ createSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'toggle',
+})
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"transferOwnership"`
+ *
+ *
+ */
+export const prepareWriteSendtagCheckoutTransferOwnership = /*#__PURE__*/ createSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'transferOwnership',
+})
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"withdrawETH"`
+ *
+ *
+ */
+export const prepareWriteSendtagCheckoutWithdrawEth = /*#__PURE__*/ createSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'withdrawETH',
+})
+
+/**
+ * Wraps __{@link simulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"withdrawToken"`
+ *
+ *
+ */
+export const prepareWriteSendtagCheckoutWithdrawToken = /*#__PURE__*/ createSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'withdrawToken',
+})
+
+/**
+ * Wraps __{@link watchContractEvent}__ with `abi` set to __{@link sendtagCheckoutAbi}__
+ *
+ *
+ */
+export const watchSendtagCheckoutEvent = /*#__PURE__*/ createWatchContractEvent({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+})
+
+/**
+ * Wraps __{@link watchContractEvent}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `eventName` set to `"OwnershipTransferred"`
+ *
+ *
+ */
+export const watchSendtagCheckoutOwnershipTransferredEvent = /*#__PURE__*/ createWatchContractEvent(
+  { abi: sendtagCheckoutAbi, address: sendtagCheckoutAddress, eventName: 'OwnershipTransferred' }
+)
+
+/**
+ * Wraps __{@link watchContractEvent}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `eventName` set to `"ReferralBonus"`
+ *
+ *
+ */
+export const watchSendtagCheckoutReferralBonusEvent = /*#__PURE__*/ createWatchContractEvent({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  eventName: 'ReferralBonus',
+})
+
+/**
+ * Wraps __{@link watchContractEvent}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `eventName` set to `"Toggled"`
+ *
+ *
+ */
+export const watchSendtagCheckoutToggledEvent = /*#__PURE__*/ createWatchContractEvent({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  eventName: 'Toggled',
 })
 
 /**
@@ -11720,6 +12116,256 @@ export const useSimulateSenderCreator = /*#__PURE__*/ createUseSimulateContract(
 export const useSimulateSenderCreatorCreateSender = /*#__PURE__*/ createUseSimulateContract({
   abi: senderCreatorAbi,
   functionName: 'createSender',
+})
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__
+ *
+ *
+ */
+export const useReadSendtagCheckout = /*#__PURE__*/ createUseReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+})
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"multisig"`
+ *
+ *
+ */
+export const useReadSendtagCheckoutMultisig = /*#__PURE__*/ createUseReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'multisig',
+})
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"open"`
+ *
+ *
+ */
+export const useReadSendtagCheckoutOpen = /*#__PURE__*/ createUseReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'open',
+})
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"owner"`
+ *
+ *
+ */
+export const useReadSendtagCheckoutOwner = /*#__PURE__*/ createUseReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'owner',
+})
+
+/**
+ * Wraps __{@link useReadContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"token"`
+ *
+ *
+ */
+export const useReadSendtagCheckoutToken = /*#__PURE__*/ createUseReadContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'token',
+})
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__
+ *
+ *
+ */
+export const useWriteSendtagCheckout = /*#__PURE__*/ createUseWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+})
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"checkout"`
+ *
+ *
+ */
+export const useWriteSendtagCheckoutCheckout = /*#__PURE__*/ createUseWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'checkout',
+})
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"renounceOwnership"`
+ *
+ *
+ */
+export const useWriteSendtagCheckoutRenounceOwnership = /*#__PURE__*/ createUseWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'renounceOwnership',
+})
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"toggle"`
+ *
+ *
+ */
+export const useWriteSendtagCheckoutToggle = /*#__PURE__*/ createUseWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'toggle',
+})
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"transferOwnership"`
+ *
+ *
+ */
+export const useWriteSendtagCheckoutTransferOwnership = /*#__PURE__*/ createUseWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'transferOwnership',
+})
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"withdrawETH"`
+ *
+ *
+ */
+export const useWriteSendtagCheckoutWithdrawEth = /*#__PURE__*/ createUseWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'withdrawETH',
+})
+
+/**
+ * Wraps __{@link useWriteContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"withdrawToken"`
+ *
+ *
+ */
+export const useWriteSendtagCheckoutWithdrawToken = /*#__PURE__*/ createUseWriteContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'withdrawToken',
+})
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__
+ *
+ *
+ */
+export const useSimulateSendtagCheckout = /*#__PURE__*/ createUseSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+})
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"checkout"`
+ *
+ *
+ */
+export const useSimulateSendtagCheckoutCheckout = /*#__PURE__*/ createUseSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'checkout',
+})
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"renounceOwnership"`
+ *
+ *
+ */
+export const useSimulateSendtagCheckoutRenounceOwnership = /*#__PURE__*/ createUseSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'renounceOwnership',
+})
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"toggle"`
+ *
+ *
+ */
+export const useSimulateSendtagCheckoutToggle = /*#__PURE__*/ createUseSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'toggle',
+})
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"transferOwnership"`
+ *
+ *
+ */
+export const useSimulateSendtagCheckoutTransferOwnership = /*#__PURE__*/ createUseSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'transferOwnership',
+})
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"withdrawETH"`
+ *
+ *
+ */
+export const useSimulateSendtagCheckoutWithdrawEth = /*#__PURE__*/ createUseSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'withdrawETH',
+})
+
+/**
+ * Wraps __{@link useSimulateContract}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `functionName` set to `"withdrawToken"`
+ *
+ *
+ */
+export const useSimulateSendtagCheckoutWithdrawToken = /*#__PURE__*/ createUseSimulateContract({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  functionName: 'withdrawToken',
+})
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link sendtagCheckoutAbi}__
+ *
+ *
+ */
+export const useWatchSendtagCheckoutEvent = /*#__PURE__*/ createUseWatchContractEvent({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+})
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `eventName` set to `"OwnershipTransferred"`
+ *
+ *
+ */
+export const useWatchSendtagCheckoutOwnershipTransferredEvent =
+  /*#__PURE__*/ createUseWatchContractEvent({
+    abi: sendtagCheckoutAbi,
+    address: sendtagCheckoutAddress,
+    eventName: 'OwnershipTransferred',
+  })
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `eventName` set to `"ReferralBonus"`
+ *
+ *
+ */
+export const useWatchSendtagCheckoutReferralBonusEvent = /*#__PURE__*/ createUseWatchContractEvent({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  eventName: 'ReferralBonus',
+})
+
+/**
+ * Wraps __{@link useWatchContractEvent}__ with `abi` set to __{@link sendtagCheckoutAbi}__ and `eventName` set to `"Toggled"`
+ *
+ *
+ */
+export const useWatchSendtagCheckoutToggledEvent = /*#__PURE__*/ createUseWatchContractEvent({
+  abi: sendtagCheckoutAbi,
+  address: sendtagCheckoutAddress,
+  eventName: 'Toggled',
 })
 
 /**

--- a/tilt/infra.Tiltfile
+++ b/tilt/infra.Tiltfile
@@ -207,6 +207,17 @@ local_resource(
 )
 
 local_resource(
+    "anvil:anvil-add-sendtag-checkout-fixtures",
+    "yarn contracts dev:anvil-add-sendtag-checkout-fixtures",
+    dir = _prj_root,
+    labels = labels,
+    resource_deps = _infra_resource_deps + [
+        "anvil:base",
+        "contracts:build",
+    ],
+)
+
+local_resource(
     "anvil:fixtures",
     "echo 🥳",
     labels = labels,
@@ -214,6 +225,7 @@ local_resource(
         "anvil:base",
         "anvil:anvil-token-paymaster-deposit",
         "anvil:anvil-deploy-fjord-send-verifier-fixtures",
+        "anvil:anvil-add-sendtag-checkout-fixtures",
     ],
 )
 


### PR DESCRIPTION
### TL;DR

Introduced a new smart contract `SendtagCheckout` for handling ERC20 token payments within the Sendtag ecosystem, along with comprehensive tests for its functionality. This contract manages transactions involving multisigs and referrer bonuses.

### What changed?
- Added `SendtagCheckout.sol` contract.
  - Handles payments and bonuses within the Sendtag system.
  - Includes functions for toggling operational status and withdrawing tokens or ETH.
- Implemented tests in `SendtagCheckout.t.sol`.
  - Test coverage includes various scenarios for the `checkout` function, withdrawal operations, and the toggle mechanism.
- Updated `wagmi/src/generated.ts` with the new contract's ABI and related definitions.

### How to test?
1. Deploy the `SendtagCheckout` contract on a testnet or local blockchain environment.
2. Run the tests provided in `SendtagCheckout.t.sol` to verify functionality.
3. Confirm that the functions related to the contract in `wagmi/src/generated.ts` operate as expected.

### Why make this change?
To facilitate the secure and efficient handling of token payments within the Sendtag ecosystem, including referrer bonuses and multisig transactions.

---

