### PR TITLE
bugfix: increase JWT Max-Age from session to 14 days

### DIFF
--- a/packages/api/src/routers/account-recovery/router.ts
+++ b/packages/api/src/routers/account-recovery/router.ts
@@ -15,7 +15,7 @@ import {
   getPasskey,
   isChallengeExpired,
 } from 'app/utils/account-recovery'
-import { mintAuthenticatedJWTToken } from 'app/utils/jwt'
+import { JWT_ACCESS_TOKEN_EXPIRY_SECS, mintAuthenticatedJWTToken } from 'app/utils/jwt'
 import { verifyMessage, hexToBytes } from 'viem'
 import { verifySignature } from 'app/utils/userop'
 import { COSEECDHAtoXY } from 'app/utils/passkeys'
@@ -123,7 +123,10 @@ export const accountRecoveryRouter = createTRPCRouter({
       const encodedJwt = encodeURIComponent(JSON.stringify([jwt, null, null, null, null, null]))
 
       console.log(`Account recovered - Recovery type: [${recoveryType}]. User: [${userId}].`)
-      ctx.res.setHeader('Set-Cookie', `sb-${SUPABASE_SUBDOMAIN}-auth-token=${encodedJwt}; Path=/`)
+      ctx.res.setHeader(
+        'Set-Cookie',
+        `sb-${SUPABASE_SUBDOMAIN}-auth-token=${encodedJwt}; Path=/; Max-Age=${JWT_ACCESS_TOKEN_EXPIRY_SECS}`
+      )
       return {
         jwt,
       }

--- a/packages/app/utils/jwt.ts
+++ b/packages/app/utils/jwt.ts
@@ -3,6 +3,9 @@ import type { SignOptions, Secret } from 'jsonwebtoken'
 
 const jwtSecret = process.env.SUPABASE_JWT_SECRET as Secret
 
+// 14 days
+export const JWT_ACCESS_TOKEN_EXPIRY_SECS = 1209600
+
 /**
  * @todo Audit capabilities for JWTs created via this method, see https://github.com/0xsend/sendapp/pull/437#discussion_r1624477143
  * @param {string} sub - subject (userId of user in the public.auth table)
@@ -10,7 +13,7 @@ const jwtSecret = process.env.SUPABASE_JWT_SECRET as Secret
  */
 export const mintAuthenticatedJWTToken = (sub: string): string => {
   const options = {
-    expiresIn: '7d',
+    expiresIn: JWT_ACCESS_TOKEN_EXPIRY_SECS,
   }
 
   return mintJWTToken('authenticated', 'authenticated', sub, options)


### PR DESCRIPTION
Increase JWT expiry to 14 days and increase cookie Max-Age from session to 14 days.

This fixes the QA issue of users being logged out as soon as their session ends (i.e. closing the browser).