### PR TITLE
login errors

### DIFF
--- a/packages/app/features/auth/sign-up/sign-up-form.tsx
+++ b/packages/app/features/auth/sign-up/sign-up-form.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Turnstile } from '@marsidev/react-turnstile'
 import {
   BigHeading,
@@ -36,7 +36,6 @@ export const SignUpForm = () => {
   const { redirectUri } = queryParams
   const toast = useToastController()
   const [captchaToken, setCaptchaToken] = useState<string | undefined>()
-  const [signInError, setSignInError] = useState<Error | null>(null)
   const [isSigningIn, setIsSigningIn] = useState(false)
 
   const { mutateAsync: getChallengeMutateAsync } = api.challenge.getChallenge.useMutation({
@@ -71,8 +70,7 @@ export const SignUpForm = () => {
 
       router.push(redirectUri ?? '/')
     } catch (error) {
-      toast.show('Failed to sign in', { preset: 'error', isUrgent: true })
-      setSignInError(error as Error)
+      toast.show(formatErrorMessage(error), { preset: 'error', isUrgent: true, duration: 10000 })
     } finally {
       setIsSigningIn(false)
     }
@@ -98,6 +96,8 @@ export const SignUpForm = () => {
       form.setError('phone', { type: 'custom', message: errorMessage })
     }
   }
+
+  useEffect(() => () => toast.hide(), [toast])
 
   return (
     <FormProvider {...form}>
@@ -195,12 +195,6 @@ export const SignUpForm = () => {
                     </ButtonText>
                   </SubmitButton>
                 </XStack>
-
-                {signInError && (
-                  <Paragraph pos={'absolute'} color="$error" bottom={0} alignSelf="center">
-                    {formatErrorMessage(signInError)}
-                  </Paragraph>
-                )}
               </YStack>
               <YStack pt="$4">
                 {!!process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY && (

--- a/packages/app/features/splash/screen.tsx
+++ b/packages/app/features/splash/screen.tsx
@@ -18,7 +18,7 @@ import { Carousel, carouselImagePositions } from 'app/features/auth/components/C
 import { SolitoImage } from 'solito/image'
 import { useLink } from 'solito/link'
 import { AnimationLayout } from '../../components/layout/animation-layout'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { formatErrorMessage } from 'app/utils/formatErrorMessage'
 import { RecoveryOptions } from '@my/api/src/routers/account-recovery/types'
 import { SubmitButton, useToastController } from '@my/ui'
@@ -249,7 +249,6 @@ function AuthButtons() {
   const toast = useToastController()
   const router = useRouter()
   const signUpLink = useLink({ href: '/auth/sign-up' })
-  const [signInError, setSignInError] = useState<Error | null>(null)
   const [isSigningIn, setIsSigningIn] = useState(false)
 
   const { mutateAsync: getChallengeMutateAsync } = api.challenge.getChallenge.useMutation({
@@ -284,12 +283,13 @@ function AuthButtons() {
 
       router.push(redirectUri ?? '/')
     } catch (error) {
-      toast.show('Failed to sign in', { preset: 'error', isUrgent: true })
-      setSignInError(error as Error)
+      toast.show(formatErrorMessage(error), { preset: 'error', isUrgent: true, duration: 10000 })
     } finally {
       setIsSigningIn(false)
     }
   }
+
+  useEffect(() => () => toast.hide(), [toast])
 
   return (
     <XStack
@@ -310,12 +310,6 @@ function AuthButtons() {
           SIGN-UP
         </Button.Text>
       </Button>
-
-      {signInError && (
-        <Paragraph pos={'absolute'} color="$error" bottom={0}>
-          {formatErrorMessage(signInError)}
-        </Paragraph>
-      )}
     </XStack>
   )
 }

--- a/packages/ui/src/components/NativeToast.tsx
+++ b/packages/ui/src/components/NativeToast.tsx
@@ -23,6 +23,7 @@ export const NativeToast = () => {
         bw={1}
         boc="color12"
         $theme-dark={{ boc: '$primary' }}
+        maxWidth="$size.22"
       >
         <YStack py="$1.5" px="$2">
           <Toast.Title>{currentToast.title}</Toast.Title>


### PR DESCRIPTION
The error is in a 10 second long toast. The toast is hidden after component unmounts so it doesn't stay up there after a successful login.

![Screenshot 2024-08-28 at 5 17 30 PM](https://github.com/user-attachments/assets/1e1d47a9-1722-4662-af2c-39cac8ecf0c1)
