### PR TITLE
Adjust condition to show backing up page

### DIFF
--- a/packages/app/features/auth/sign-up/sign-up-form.tsx
+++ b/packages/app/features/auth/sign-up/sign-up-form.tsx
@@ -85,7 +85,11 @@ export const SignUpForm = () => {
 
       router.push(redirectUri ?? '/')
     } catch (error) {
-      if (isPhoneAlreadyUsed && error instanceof DOMException && error.name === 'NotAllowedError') {
+      if (
+        isPhoneAlreadyUsed &&
+        error.constructor.name === 'DOMException' &&
+        error.name === 'NotAllowedError'
+      ) {
         setPageState(PageState.BackUpPrompt)
         return
       }


### PR DESCRIPTION
Changed condition to show backing up page on sign-up route from checking if error is instance of DOMException to checking if error's constructor's name is DOMException. From business logic perspective it's gonna be the same as this is the only error with the given name that will occur in the system, but this setup is easier to mock from web-authenticator