### PR TITLE
fix(app): send streak shows ongoing

### DIFF
--- a/packages/app/utils/dateHelper.test.ts
+++ b/packages/app/utils/dateHelper.test.ts
@@ -3,6 +3,7 @@ import {
   adjustDatePickerDateToTimezone,
   adjustUTCDateForTimezone,
   CommentsTime,
+  isEqualCalendarDate,
 } from './dateHelper'
 describe('CommentsTime', () => {
   beforeAll(() => {
@@ -71,5 +72,29 @@ describe('adjustDatePickerDateToTimezone', () => {
     const localDate = new Date('2024-12-13T00:00:00-05:00')
     const adjustedDate = adjustDatePickerDateToTimezone(localDate)
     expect(adjustedDate.toISOString()).toBe('2024-12-13T05:00:00.000Z')
+  })
+})
+
+describe('isSameDay', () => {
+  it('should return true if the dates are the same', () => {
+    const date1 = new Date('2024-12-13T00:00:00.000Z')
+    const date2 = new Date('2024-12-13T00:00:00.000Z')
+    expect(isEqualCalendarDate(date1, date2)).toBe(true)
+  })
+
+  it('should return false if the dates are not the same', () => {
+    const date1 = new Date('2024-12-13T00:00:00.000Z')
+    const date2 = new Date('2024-12-14T00:00:00.000Z')
+    expect(isEqualCalendarDate(date1, date2)).toBe(false)
+  })
+  it('should return false if the dates are in different years', () => {
+    const date1 = new Date('2024-12-13T00:00:00.000Z')
+    const date2 = new Date('2025-12-13T00:00:00.000Z')
+    expect(isEqualCalendarDate(date1, date2)).toBe(false)
+  })
+  it('should return false if the dates are in different months', () => {
+    const date1 = new Date('2024-12-13T00:00:00.000Z')
+    const date2 = new Date('2024-11-13T00:00:00.000Z')
+    expect(isEqualCalendarDate(date1, date2)).toBe(false)
   })
 })

--- a/packages/app/utils/dateHelper.ts
+++ b/packages/app/utils/dateHelper.ts
@@ -59,3 +59,17 @@ export const adjustDatePickerDateToTimezone = (date: Date): Date => {
   const adjustedTime = date.getTime() - timezoneOffsetMillis
   return new Date(adjustedTime)
 }
+
+/**
+ * Checks if two dates are in the same calendar day.
+ * @param date1 - The first date to compare.
+ * @param date2 - The second date to compare.
+ * @returns True if the dates are in the same calendar day, false otherwise.
+ */
+export const isEqualCalendarDate = (date1: Date, date2: Date): boolean => {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  )
+}

--- a/packages/snaplet/README.md
+++ b/packages/snaplet/README.md
@@ -2,6 +2,10 @@
 
 Snaplet is used for seeding our local development environment with production-like data. It is used both as a CLI tool and as a typescript library.
 
+> [!IMPORTANT]
+> The following commands should be run within the snaplet package directory.
+> `cd packages/snaplet`
+
 It seeds our database using two main methods:
 
 ## Seeding

--- a/packages/snaplet/snaplet.config.ts
+++ b/packages/snaplet/snaplet.config.ts
@@ -148,21 +148,7 @@ export default defineConfig({
         return row
       },
       distribution_verifications: ({ row }) => {
-        if (row.metadata === null) {
-          return {}
-        }
-
-        const { metadata } = row as { metadata: { [key: string]: string } }
-
-        // if (metadata.tag !== undefined) {
-        //   metadata.tag = tagName(copycat.username(metadata.tag))
-        // }
-
-        return {
-          metadata: {
-            ...metadata,
-          },
-        }
+        return row
       },
       referrals: ({ row }) => {
         return row

--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -1426,6 +1426,7 @@ export type Database = {
         fixed_value: number
         bips_value: number
         metadata: Json
+        created_at: string
       }
     }
   }

--- a/supabase/migrations/20250102214349_update_distribution_verifications_summary_for_pending_send_streak.sql
+++ b/supabase/migrations/20250102214349_update_distribution_verifications_summary_for_pending_send_streak.sql
@@ -1,0 +1,46 @@
+set check_function_bodies = off;
+
+alter type verification_value_info add attribute created_at timestamp with time zone;
+
+CREATE OR REPLACE VIEW "public"."distribution_verifications_summary" WITH ( security_barrier ) AS
+WITH base_counts AS (
+    SELECT
+        dv.distribution_id,
+        dv.user_id,
+        dv.type,
+        dv.created_at,
+        SUM(dv.weight) AS total_weight,
+        jsonb_agg(dv.metadata) AS combined_metadata
+    FROM
+        distribution_verifications dv
+            LEFT JOIN distribution_verification_values dvv ON dvv.distribution_id = dv.distribution_id
+            AND dvv.type = dv.type
+    WHERE
+        dv.user_id = auth.uid()
+    GROUP BY
+        dv.distribution_id,
+        dv.user_id,
+        dv.type,
+        dv.created_at
+)
+SELECT
+    dvv.distribution_id,
+    COALESCE(bc.user_id, auth.uid()) AS user_id,
+    array_agg(ROW (dvv.type, COALESCE(bc.total_weight, 0), dvv.fixed_value, dvv.bips_value, COALESCE(bc.combined_metadata, '[]'::jsonb), bc.created_at)::verification_value_info) AS verification_values,
+    array_agg(ROW (dvv.type, CASE WHEN (COALESCE(dvv.multiplier_min, 1.0) = 1.0
+        AND COALESCE(dvv.multiplier_max, 1.0) = 1.0
+        AND COALESCE(dvv.multiplier_step, 0.0) = 0.0)
+        OR COALESCE(bc.total_weight, 0) = 0 THEN
+                                      NULL
+                                  ELSE
+                                      LEAST(dvv.multiplier_min +((COALESCE(bc.total_weight, 1) - 1) * dvv.multiplier_step), dvv.multiplier_max)
+        END, dvv.multiplier_min, dvv.multiplier_max, dvv.multiplier_step, COALESCE(bc.combined_metadata, '[]'::jsonb))::multiplier_info) AS multipliers
+FROM
+    distribution_verification_values dvv
+        LEFT JOIN base_counts bc ON bc.distribution_id = dvv.distribution_id
+        AND bc.type = dvv.type
+GROUP BY
+    dvv.distribution_id,
+    COALESCE(bc.user_id, auth.uid());
+
+


### PR DESCRIPTION
Instead of showing completed, send streak will show ongoing while in the middle of distribution qualification. It uses `created_at` on the distribution verification for checking when the streak was last reached.
