### PR TITLE
Fix no account bug after logout

### DIFF
--- a/apps/next/pages/index.tsx
+++ b/apps/next/pages/index.tsx
@@ -29,7 +29,7 @@ export const Page: NextPageWithLayout<InferGetServerSidePropsType<typeof getServ
   const [carouselProgress, setCarouselProgress] = useState(0)
   const queryClient = useQueryClient()
 
-  const cancelAndInvalidateAccountsQueries = useCallback(async () => {
+  const cancelAndRemoveAccountsQueries = useCallback(async () => {
     if (!session) {
       const options = { queryKey: [useSendAccount.queryKey] }
       await queryClient.cancelQueries(options)
@@ -42,8 +42,8 @@ export const Page: NextPageWithLayout<InferGetServerSidePropsType<typeof getServ
   }, [carouselImages, images])
 
   useEffect(() => {
-    void cancelAndInvalidateAccountsQueries()
-  }, [cancelAndInvalidateAccountsQueries])
+    void cancelAndRemoveAccountsQueries()
+  }, [cancelAndRemoveAccountsQueries])
 
   return (
     <>

--- a/apps/next/pages/index.tsx
+++ b/apps/next/pages/index.tsx
@@ -11,11 +11,13 @@ import Head from 'next/head'
 import { userOnboarded } from 'utils/userOnboarded'
 import type { NextPageWithLayout } from './_app'
 import { AuthCarouselContext } from 'app/features/auth/AuthCarouselContext'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { getRemoteAssets } from 'utils/getRemoteAssets'
 import type { GetPlaiceholderImage } from 'app/utils/getPlaiceholderImage'
 
 import { MobileButtonRowLayout } from 'app/components/MobileButtonRowLayout'
+import { useQueryClient } from '@tanstack/react-query'
+import { useSendAccount } from 'app/utils/send-accounts/useSendAccounts'
 
 const log = debug('app:pages:index')
 
@@ -25,10 +27,23 @@ export const Page: NextPageWithLayout<InferGetServerSidePropsType<typeof getServ
   const { session } = useUser()
   const [carouselImages, setCarouselImages] = useState<GetPlaiceholderImage[]>([])
   const [carouselProgress, setCarouselProgress] = useState(0)
+  const queryClient = useQueryClient()
+
+  const cancelAndInvalidateAccountsQueries = useCallback(async () => {
+    if (!session) {
+      const options = { queryKey: [useSendAccount.queryKey] }
+      await queryClient.cancelQueries(options)
+      queryClient.removeQueries(options)
+    }
+  }, [session, queryClient])
 
   useEffect(() => {
     if (carouselImages.length === 0) setCarouselImages(images)
   }, [carouselImages, images])
+
+  useEffect(() => {
+    void cancelAndInvalidateAccountsQueries()
+  }, [cancelAndInvalidateAccountsQueries])
 
   return (
     <>


### PR DESCRIPTION
**Issue**: When user logout and login again on the same or different account, while home screen is loading there is no loader shown, instead there is a no send account message displayed

**root cause**: After user is signed out some parts of the application are refreshing send account query (before redirected to the splash screen), no results will be returned because user is signed out, null value will be stored in query cache. When logging in back again, this cache is still there, so account query is not in loading state, and also there is no data. Thats the reason no account message is shown.

**implemented solution**: when splash screen is shown, session is for sure gone, then cancel all ongoing account queries and remove query cache as it is invalid anyway