### PR TITLE
feat: add tranche_id to distributions

### DIFF
--- a/apps/distributor/src/distributorv2.test.ts
+++ b/apps/distributor/src/distributorv2.test.ts
@@ -89,6 +89,7 @@ describe('Distributor V2 Worker', () => {
     const distribution = {
       id: 4,
       number: 4,
+      tranche_id: 4,
       amount: '10000',
       hodler_pool_bips: 10000,
       bonus_pool_bips: 0,

--- a/apps/distributor/src/distributorv2.ts
+++ b/apps/distributor/src/distributorv2.ts
@@ -145,7 +145,7 @@ export class DistributorV2Worker {
     )
     if (
       await isMerkleDropActive({
-        number: distribution.number,
+        tranche_id: distribution.tranche_id,
         chain_id: distribution.chain_id,
         merkle_drop_addr: distribution.merkle_drop_addr,
       })

--- a/apps/distributor/src/supabase.ts
+++ b/apps/distributor/src/supabase.ts
@@ -35,6 +35,7 @@ function fetchDistributionQuery() {
       merkle_drop_addr,
       name,
       number,
+      tranche_id,
       qualification_end,
       qualification_start,
       snapshot_block_num,

--- a/apps/distributor/src/wagmi.ts
+++ b/apps/distributor/src/wagmi.ts
@@ -54,7 +54,7 @@ export async function fetchAllBalances({
 }
 
 export async function isMerkleDropActive(distribution: {
-  number: number
+  tranche_id: number
   chain_id: number
   merkle_drop_addr: string | null
 }) {
@@ -63,6 +63,6 @@ export async function isMerkleDropActive(distribution: {
     abi: sendMerkleDropAbi,
     address,
     functionName: 'trancheActive',
-    args: [BigInt(distribution.number - 1)], // tranche is 0-indexed
+    args: [BigInt(distribution.tranche_id)], // tranche is 0-indexed
   })
 }

--- a/packages/app/components/MobileButtonRowLayout.tsx
+++ b/packages/app/components/MobileButtonRowLayout.tsx
@@ -170,8 +170,9 @@ const ActivityRewards = ({ children, ...props }: XStackProps) => {
   const isVisible =
     distribution !== undefined &&
     shareAmount !== undefined &&
-    shareAmount > 0 &&
+    shareAmount > 0n &&
     direction !== 'down'
+
   const distributionMonth = distribution?.timezone_adjusted_qualification_end.toLocaleString(
     'default',
     {

--- a/packages/app/utils/distributions.ts
+++ b/packages/app/utils/distributions.ts
@@ -58,6 +58,7 @@ function fetchDistributions(supabase: SupabaseClient<Database>) {
       merkle_drop_addr,
       name,
       number,
+      tranche_id,
       qualification_end,
       qualification_start,
       snapshot_block_num,
@@ -457,7 +458,7 @@ export function useGenerateClaimUserOp({
   share?: UseDistributionsResultData[number]['distribution_shares'][number]
   nonce?: bigint
 }): UseQueryResult<UserOperation<'v0.7'>> {
-  const trancheId = BigInt(distribution.number - 1) // tranches are 0-indexed
+  const trancheId = BigInt(distribution.tranche_id) // tranches are 0-indexed
   const chainId = distribution.chain_id as keyof typeof sendMerkleDropAddress
   const merkleDropAddress = byteaToHex(distribution.merkle_drop_addr as `\\x${string}`)
 
@@ -522,7 +523,10 @@ export function useGenerateClaimUserOp({
     enabled: enabled,
     queryFn: () => {
       assert(!!sender && isAddress(sender), 'Invalid send account address')
-      assert(typeof amount_after_slash === 'number' && amount_after_slash > 0, 'Invalid amount')
+      assert(
+        typeof amount_after_slash === 'string' && BigInt(amount_after_slash) > 0n,
+        'Invalid amount'
+      )
       assert(typeof nonce === 'bigint' && nonce >= 0n, 'Invalid nonce')
 
       const callData = encodeFunctionData({
@@ -573,7 +577,7 @@ export const usePrepareSendMerkleDropClaimTrancheWrite = ({
   distribution,
   share,
 }: SendMerkleDropClaimTrancheArgs) => {
-  const trancheId = BigInt(distribution.number - 1) // tranches are 0-indexed
+  const trancheId = BigInt(distribution.tranche_id) // tranches are 0-indexed
   const chainId = distribution.chain_id as keyof typeof sendMerkleDropAddress
   const merkleDropAddress = byteaToHex(distribution.merkle_drop_addr as `\\x${string}`)
   // get the merkle proof from the database

--- a/packages/contracts/script/anvil-add-send-merkle-drop-fixtures.ts
+++ b/packages/contracts/script/anvil-add-send-merkle-drop-fixtures.ts
@@ -80,54 +80,56 @@ void (async function main() {
     throw distributionError
   }
 
-  console.log(chalk.red('TODO(@0xBigBoss) move this to the trpc API'))
-  process.exit(1)
-  return
+  console.log(
+    chalk.blue('Geting distribution merkle root from API for distribution', distribution.id)
+  )
+  const data = await fetch('http://localhost:3050/distributor/merkle', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE}`,
+    },
+    body: JSON.stringify({ id: distribution?.id }),
+  }).then(async (res) => (res.ok ? res.json() : Promise.reject(await res.text())))
 
-  //   console.log(chalk.blue('Geting distribution merkle root from API'))
-  //   const { root, total } = await fetch('http://localhost:3050/distributor/merkle', {
-  //     method: 'POST',
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //       Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE}`,
-  //     },
-  //     body: JSON.stringify({ id: distribution?.id }),
-  //   }).then(async (res) => (res.ok ? res.json() : Promise.reject(await res.text())))
+  await Bun.write('distribution-merkle-tree.json', JSON.stringify(data, null, 2))
 
-  //   $.env.MERKLE_ROOT = root
-  //   $.env.AMOUNT = total
-  //   $.env.SEND_MERKLE_DROP_ADDRESS = merkleDropAddress
+  const { root, total } = data
 
-  //   console.log(chalk.blue('Sending 10 ether to the airdrop multisig...'))
-  //   await $`cast send --rpc-url http://localhost:8546 \
-  //             --unlocked \
-  //             --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
-  //             ${AIRDROP_MULTISIG_SAFE} \
-  //             --value 10ether`
+  $.env.MERKLE_ROOT = root
+  $.env.AMOUNT = total
+  $.env.SEND_MERKLE_DROP_ADDRESS = merkleDropAddress
 
-  //   console.log(chalk.blue('Impersonating the airdrop multisig...'))
-  //   await $`cast rpc --rpc-url http://localhost:8546 \
-  //     anvil_impersonateAccount \
-  //     ${AIRDROP_MULTISIG_SAFE}`
+  console.log(chalk.blue('Sending 10 ether to the airdrop multisig...'))
+  await $`cast send --rpc-url http://localhost:8546 \
+              --unlocked \
+              --from 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 \
+              ${AIRDROP_MULTISIG_SAFE} \
+              --value 10ether`
 
-  //   console.log(chalk.blue('Adding a tranche to the airdrop...'))
-  //   await $`forge script ./script/CreateSendDistributionTranche.s.sol:CreateSendDistributionTrancheScript \
-  //               -vvvv \
-  //               --fork-url http://localhost:8546 \
-  //               --unlocked \
-  //               --sender ${AIRDROP_MULTISIG_SAFE} \
-  //               --broadcast`
+  console.log(chalk.blue('Impersonating the airdrop multisig...'))
+  await $`cast rpc --rpc-url http://localhost:8546 \
+      anvil_impersonateAccount \
+      ${AIRDROP_MULTISIG_SAFE}`
 
-  //   console.log(chalk.blue('Stop impersonating the airdrop multisig...'))
-  //   await $`cast rpc --rpc-url http://localhost:8546 anvil_stopImpersonatingAccount ${AIRDROP_MULTISIG_SAFE}`
+  console.log(chalk.blue('Adding a tranche to the airdrop...'))
+  await $`forge script ./script/CreateSendDistributionTranche.s.sol:CreateSendDistributionTrancheScript \
+                -vvvv \
+                --fork-url http://localhost:8546 \
+                --unlocked \
+                --sender ${AIRDROP_MULTISIG_SAFE} \
+                --broadcast`
 
-  //   console.log(chalk.blue('Disable auto-mining...'))
-  //   await $`cast rpc --rpc-url http://localhost:8546 evm_setAutomine false`
+  console.log(chalk.blue('Stop impersonating the airdrop multisig...'))
+  await $`cast rpc --rpc-url http://localhost:8546 anvil_stopImpersonatingAccount ${AIRDROP_MULTISIG_SAFE}`
 
-  //   console.log(chalk.blue(`Re-enable interval mining... ${$.env.ANVIL_BLOCK_TIME ?? '2'}`))
-  //   await $`cast rpc --rpc-url http://localhost:8546 evm_setIntervalMining ${
-  //     $.env.ANVIL_BLOCK_TIME ?? '2'
-  //   }` // mimics Tiltfile default
+  console.log(chalk.blue('Disable auto-mining...'))
+  await $`cast rpc --rpc-url http://localhost:8546 evm_setAutomine false`
 
-  //   console.log(chalk.green('Done!'))
+  console.log(chalk.blue(`Re-enable interval mining... ${$.env.ANVIL_BLOCK_TIME ?? '2'}`))
+  await $`cast rpc --rpc-url http://localhost:8546 evm_setIntervalMining ${
+    $.env.ANVIL_BLOCK_TIME ?? '2'
+  }` // mimics Tiltfile default
+
+  console.log(chalk.green('Done!'))
 })()

--- a/packages/snaplet/.snaplet/dataModel.json
+++ b/packages/snaplet/.snaplet/dataModel.json
@@ -1709,6 +1709,20 @@
           "maxLength": null
         },
         {
+          "id": "public.distributions.tranche_id",
+          "name": "tranche_id",
+          "columnName": "tranche_id",
+          "type": "int4",
+          "isRequired": true,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": false,
+          "sequence": false,
+          "hasDefaultValue": false,
+          "isId": false,
+          "maxLength": null
+        },
+        {
           "name": "distribution_shares",
           "type": "distribution_shares",
           "isRequired": false,
@@ -1767,16 +1781,17 @@
       ],
       "uniqueConstraints": [
         {
-          "name": "distributions_number_key",
+          "name": "distributions_pkey",
           "fields": [
-            "number"
+            "id"
           ],
           "nullNotDistinct": false
         },
         {
-          "name": "distributions_pkey",
+          "name": "distributions_tranche_id_key",
           "fields": [
-            "id"
+            "merkle_drop_addr",
+            "tranche_id"
           ],
           "nullNotDistinct": false
         }

--- a/packages/workflows/src/distribution-workflow/wagmi.ts
+++ b/packages/workflows/src/distribution-workflow/wagmi.ts
@@ -38,6 +38,6 @@ export function fetchAllBalances({
 export async function isMerkleDropActive(distribution: Tables<'distributions'>) {
   return readSendMerkleDropTrancheActive(config, {
     chainId: distribution.chain_id as keyof typeof sendMerkleDropAddress,
-    args: [BigInt(distribution.number - 1)], // number is 1-indexed
+    args: [BigInt(distribution.tranche_id)], // number is 1-indexed
   })
 }

--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -309,6 +309,7 @@ export type Database = {
           snapshot_block_num: number | null
           token_addr: string | null
           token_decimals: number | null
+          tranche_id: number
           updated_at: string
         }
         Insert: {
@@ -330,6 +331,7 @@ export type Database = {
           snapshot_block_num?: number | null
           token_addr?: string | null
           token_decimals?: number | null
+          tranche_id: number
           updated_at?: string
         }
         Update: {
@@ -351,6 +353,7 @@ export type Database = {
           snapshot_block_num?: number | null
           token_addr?: string | null
           token_decimals?: number | null
+          tranche_id?: number
           updated_at?: string
         }
         Relationships: []

--- a/supabase/migrations/20250126191544_add_tranche_id_to_distributions.sql
+++ b/supabase/migrations/20250126191544_add_tranche_id_to_distributions.sql
@@ -1,0 +1,14 @@
+alter table distributions
+  add column tranche_id integer,
+  drop constraint distributions_number_key;
+
+-- tranche_id is 0-indexed whereas number is 1-indexed
+update distributions set tranche_id = number - 1 where number < 11; -- distribution 11 got a new address and reset the tranche id
+update distributions set tranche_id = 3 where number = 11; -- base merkle drop contracts started at 4
+
+-- merkle drop address also changed for distribution 11
+update distributions set merkle_drop_addr = '\x2c1630cd8f40d0458b7b5849e6cc2904a7d18a57' where number = 11;
+
+alter table distributions
+  alter column tranche_id set not null,
+  add constraint distributions_tranche_id_key unique (merkle_drop_addr, tranche_id);

--- a/supabase/tests/distribution_hodler_addresses_test.sql
+++ b/supabase/tests/distribution_hodler_addresses_test.sql
@@ -23,6 +23,7 @@ VALUES (
     8453);
 INSERT INTO distributions(
     number,
+    tranche_id,
     name,
     description,
     amount,
@@ -35,6 +36,7 @@ INSERT INTO distributions(
     claim_end,
     chain_id)
 VALUES (
+    123,
     123,
     'distribution #123',
     'Description',

--- a/supabase/tests/distributions_test.sql
+++ b/supabase/tests/distributions_test.sql
@@ -225,6 +225,7 @@ SELECT
     set_config('role', 'service_role', TRUE);
 INSERT INTO distributions(
     number,
+    tranche_id,
     name,
     description,
     amount,
@@ -237,6 +238,7 @@ INSERT INTO distributions(
     claim_end,
     chain_id)
 VALUES (
+    123,
     123,
     'distribution #123',
     'Description',
@@ -372,9 +374,9 @@ SELECT
     is_empty('SELECT * FROM distributions WHERE number = 123', 'Anon cannot read the distributions.');
 SELECT
     throws_ok($$ INSERT INTO distributions(
-            number, name, description, amount, hodler_pool_bips, bonus_pool_bips, fixed_pool_bips, qualification_start, qualification_end, claim_end, chain_id)
+            number, tranche_id, name, description, amount, hodler_pool_bips, bonus_pool_bips, fixed_pool_bips, qualification_start, qualification_end, claim_end, chain_id)
         VALUES (
-            1234, 'distribution #1234', 'Description', 100000, 1000000, 1000000, 1000000, '2023-01-01T00:00:00.000Z', '2023-01-31T00:00:00.000Z', '2023-02-28T00:00:00.000Z', 8453);
+            1234, 1234, 'distribution #1234', 'Description', 100000, 1000000, 1000000, 1000000, '2023-01-01T00:00:00.000Z', '2023-01-31T00:00:00.000Z', '2023-02-28T00:00:00.000Z', 8453);
 $$,
 'new row violates row-level security policy for table "distributions"',
 'Only the service role can insert records.');
@@ -382,9 +384,9 @@ SELECT
     tests.authenticate_as('bob');
 SELECT
     throws_ok($$ INSERT INTO distributions(
-            number, name, description, amount, hodler_pool_bips, bonus_pool_bips, fixed_pool_bips, qualification_start, qualification_end, claim_end, chain_id)
+            number, tranche_id, name, description, amount, hodler_pool_bips, bonus_pool_bips, fixed_pool_bips, qualification_start, qualification_end, claim_end, chain_id)
         VALUES (
-            1234, 'distribution #1234', 'Description', 100000, 1000000, 1000000, 1000000, '2023-01-01T00:00:00.000Z', '2023-01-31T00:00:00.000Z', '2023-02-28T00:00:00.000Z', 8453);
+            1234, 1234, 'distribution #1234', 'Description', 100000, 1000000, 1000000, 1000000, '2023-01-01T00:00:00.000Z', '2023-01-31T00:00:00.000Z', '2023-02-28T00:00:00.000Z', 8453);
 $$,
 'new row violates row-level security policy for table "distributions"',
 'Only the service role can insert records.');

--- a/tilt/infra.Tiltfile
+++ b/tilt/infra.Tiltfile
@@ -172,19 +172,6 @@ local_resource(
 )
 
 local_resource(
-    "anvil:anvil-deploy-send-merkle-drop-fixtures",
-    "yarn contracts dev:deploy-send-merkle-drop",
-    auto_init = False,
-    dir = _prj_root,
-    labels = labels,
-    resource_deps = _infra_resource_deps + [
-        "anvil:base",
-        "contracts:build",
-    ],
-    trigger_mode = TRIGGER_MODE_MANUAL,
-)
-
-local_resource(
     "anvil:anvil-add-send-merkle-drop-fixtures",
     "yarn contracts dev:anvil-add-send-merkle-drop-fixtures",
     auto_init = False,
@@ -193,7 +180,6 @@ local_resource(
     resource_deps = _infra_resource_deps + [
         "anvil:base",
         "contracts:build",
-        "anvil:anvil-deploy-send-merkle-drop-fixtures",
     ],
     trigger_mode = TRIGGER_MODE_MANUAL,
 )


### PR DESCRIPTION
This was a miss when deploying the new send token merkle drop for the send token upgrade.

The tranche starts at 3 since we reused the base merkle drop contract when migrating to Base.

We are going to use tranche ID 3 for the new send token merkle drop contract for distribution 11 after the send token upgrade.
