### PR TITLE
Hide progress when no send_slash exists

### DIFF
--- a/packages/app/features/account/rewards/activity/screen.tsx
+++ b/packages/app/features/account/rewards/activity/screen.tsx
@@ -553,6 +553,12 @@ const ProgressCard = ({
   previousDistribution?: UseDistributionsResultData[number]
   verificationsQuery: DistributionsVerificationsQuery
 }) => {
+  const sendSlash = distribution.send_slash.at(0)
+
+  if (!sendSlash) {
+    return null
+  }
+
   const verifications = verificationsQuery.data
 
   if (verificationsQuery.isLoading) {
@@ -569,10 +575,9 @@ const ProgressCard = ({
     return null
   }
 
-  const sendSlash = distribution.send_slash.at(0)
   const sendCeiling = verifications.verification_values.find(({ type }) => type === 'send_ceiling')
 
-  if (!sendSlash || !sendCeiling) {
+  if (!sendCeiling) {
     return (
       <YStack f={1} w={'100%'} gap="$5">
         <H3 fontWeight={'600'} color={'$color12'}>


### PR DESCRIPTION
## Summary 

The PR introduces a null check for `sendSlash` to prevent undefined reference errors and improve code reliability. It also simplifies conditional logic and improves handling of incomplete distribution data.


## Changes Made

- Added null check for `sendSlash`
- Improved handling of incomplete distribution data
- Simplified conditional logic

_written by Kolwaii, your beloved blockchain engineer AI agent_