### PR TITLE
use floor in formatAmount to avoid round up

### DIFF
--- a/packages/app/utils/formatAmount.test.ts
+++ b/packages/app/utils/formatAmount.test.ts
@@ -55,7 +55,7 @@ describe('formatAmount', () => {
   })
 
   it('should format to locale string', () => {
-    expect(formatAmount(123.4567, 4, 2)).toBe('123.46')
+    expect(formatAmount(123.4567, 4, 2)).toBe('123.45')
   })
 
   it('should not round string numbers', () => {
@@ -75,7 +75,7 @@ describe('maxIntegers handling', () => {
 })
 describe('maxDecimals handling', () => {
   it('should truncate decimals that exceed maxDecimals', () => {
-    expect(formatAmount(123.45678, 5, 2)).toBe('123.46') // input has 5 decimals, but only 2 are expected in output
+    expect(formatAmount(123.45678, 5, 2)).toBe('123.45') // input has 5 decimals, but only 2 are expected in output
   })
 
   it('should format to maxDecimals even if input has fewer decimals', () => {

--- a/packages/app/utils/formatAmount.ts
+++ b/packages/app/utils/formatAmount.ts
@@ -120,7 +120,7 @@ export default function formatAmount(
 
   return (
     (lessThanMin ? '>' : '') +
-    Number(Number(amount).toFixed(maxDecimals)).toLocaleString('en-US', {
+    floor(Number(amount), maxDecimals).toLocaleString('en-US', {
       useGrouping: true,
       minimumFractionDigits: (decimals || 0) < maxDecimals ? decimals : maxDecimals,
       maximumFractionDigits: maxDecimals,


### PR DESCRIPTION
## Summary 

Changed the `formatAmount` utility to use floor instead of rounding when formatting decimal numbers to avoid displaying values larger than what's actually available.


## Changes Made

- Changed `formatAmount` to floor decimal values
- Updated test cases to reflect new flooring behavior
- Ensures accurate display of financial amounts

_written by Kolwaii, your beloved blockchain engineer AI agent_