### PR TITLE
Adjust memoized safe area insets

### DIFF
--- a/packages/app/components/MobileButtonRowLayout.tsx
+++ b/packages/app/components/MobileButtonRowLayout.tsx
@@ -9,7 +9,6 @@ import {
   H3,
   useMedia,
   AnimatePresence,
-  useSafeAreaInsets,
 } from '@my/ui'
 import { HomeButtons } from '../features/home/HomeButtons'
 import { useScrollDirection } from '../provider/scroll'
@@ -44,14 +43,12 @@ const MobileButtonRow = ({
   isLoading,
   isVisible,
 }: { children: React.ReactElement; isLoading: boolean; isVisible: boolean } & XStackProps) => {
-  const isPwa = usePwa()
   const media = useMedia()
-  const { sab } = useSafeAreaInsets()
 
   return (
     <Stack
       w={'100%'}
-      pb={isPwa ? sab : '$5'}
+      pb={'$3'}
       px="$4"
       $platform-web={{
         position: 'fixed',

--- a/packages/ui/src/utils/useSafeAreaInsets.ts
+++ b/packages/ui/src/utils/useSafeAreaInsets.ts
@@ -1,37 +1,24 @@
-import { useMemo } from 'react'
+import { useLayoutEffect, useState } from 'react'
 
 const sanitizeSafeAreaInset = (value: string) => {
   const sanitizedInset = value.endsWith('px') ? Number(value.slice(0, -2)) : Number(value)
   return Number.isNaN(sanitizedInset) ? 0 : sanitizedInset
 }
 
-// The values will only be recalculated if the component is unmounted and remounted
 export const useSafeAreaInsets = () => {
-  // @todo: SSR breaks insets
-
   if (typeof window === 'undefined') return { sat: 0, sar: 0, sab: 0, sal: 0 }
-  return useMemo(() => {
-    const sat = sanitizeSafeAreaInset(
-      getComputedStyle(document.documentElement).getPropertyValue('--sat')
-    )
-    console.log(getComputedStyle(document.documentElement).getPropertyValue('--sat'))
 
-    const sab = sanitizeSafeAreaInset(
-      getComputedStyle(document.documentElement).getPropertyValue('--sab')
-    )
+  const [insets, setInsets] = useState({ sat: 0, sar: 0, sab: 0, sal: 0 })
 
-    const sar = sanitizeSafeAreaInset(
-      getComputedStyle(document.documentElement).getPropertyValue('--sar')
-    )
-    const sal = sanitizeSafeAreaInset(
-      getComputedStyle(document.documentElement).getPropertyValue('--sal')
-    )
+  useLayoutEffect(() => {
+    const styles = getComputedStyle(document.documentElement)
+    const sat = sanitizeSafeAreaInset(styles.getPropertyValue('--sat')) || 24
+    const sab = sanitizeSafeAreaInset(styles.getPropertyValue('--sab')) || 40
+    const sar = sanitizeSafeAreaInset(styles.getPropertyValue('--sar'))
+    const sal = sanitizeSafeAreaInset(styles.getPropertyValue('--sal'))
 
-    return {
-      sat: !sat ? 24 : sat,
-      sab: !sab ? 40 : sab,
-      sar,
-      sal,
-    }
+    setInsets({ sat, sab, sar, sal })
   }, [])
+
+  return insets
 }


### PR DESCRIPTION
## Summary 

The PR simplifies the `useSafeAreaInsets` hook, removes the `isPwa` check in `MobileButtonRow`, and adjusts the memoized safe area insets.


## Changes Made

- Simplified `useSafeAreaInsets` hook
- Removed `isPwa` check in `MobileButtonRow`
- Updated `pb` prop in `MobileButtonRow` to a fixed value

_written by Kolwaii, your beloved blockchain engineer AI agent_