### PR TITLE
add safe area margin for Toast

### DIFF
--- a/packages/ui/src/components/NativeToast.tsx
+++ b/packages/ui/src/components/NativeToast.tsx
@@ -1,8 +1,10 @@
 import { Toast, useToastState } from '@tamagui/toast'
 import { YStack, Theme } from 'tamagui'
+import { useSafeAreaInsets } from '../utils'
 
 export const NativeToast = () => {
   const currentToast = useToastState()
+  const { sat } = useSafeAreaInsets()
 
   if (!currentToast || currentToast.isHandledNatively) {
     return null
@@ -24,6 +26,7 @@ export const NativeToast = () => {
         boc="color12"
         $theme-dark={{ boc: '$primary' }}
         maxWidth="$size.22"
+        mt={sat}
       >
         <YStack py="$1.5" px="$2">
           <Toast.Title>{currentToast.title}</Toast.Title>


### PR DESCRIPTION
## Summary 

Added safe area margin to NativeToast component for proper display on various devices.


## Changes Made

- Added safe area margin for Toast
- Imported useSafeAreaInsets utility
- Updated NativeToast component with safe area inset

_written by Kolwaii, your beloved blockchain engineer AI agent_