### PR TITLE
fix SSR problems for safe area insets

### DIFF
--- a/packages/ui/src/utils/useSafeAreaInsets.ts
+++ b/packages/ui/src/utils/useSafeAreaInsets.ts
@@ -1,23 +1,39 @@
-import { useLayoutEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 const sanitizeSafeAreaInset = (value: string) => {
+  // Handle env() function values
+  if (value.includes('env')) return 0
   const sanitizedInset = value.endsWith('px') ? Number(value.slice(0, -2)) : Number(value)
   return Number.isNaN(sanitizedInset) ? 0 : sanitizedInset
 }
 
 export const useSafeAreaInsets = () => {
-  if (typeof window === 'undefined') return { sat: 0, sar: 0, sab: 0, sal: 0 }
-
   const [insets, setInsets] = useState({ sat: 0, sar: 0, sab: 0, sal: 0 })
 
-  useLayoutEffect(() => {
-    const styles = getComputedStyle(document.documentElement)
-    const sat = sanitizeSafeAreaInset(styles.getPropertyValue('--sat')) || 24
-    const sab = sanitizeSafeAreaInset(styles.getPropertyValue('--sab')) || 40
-    const sar = sanitizeSafeAreaInset(styles.getPropertyValue('--sar'))
-    const sal = sanitizeSafeAreaInset(styles.getPropertyValue('--sal'))
+  useEffect(() => {
+    if (typeof window === 'undefined') return
 
-    setInsets({ sat, sab, sar, sal })
+    const updateInsets = () => {
+      // Force a repaint to ensure env() values are calculated
+      document.documentElement.style.display = 'none'
+      document.documentElement.offsetHeight // Force reflow
+      document.documentElement.style.display = ''
+
+      const styles = getComputedStyle(document.documentElement)
+      const sat = sanitizeSafeAreaInset(styles.getPropertyValue('--sat')) || 24
+      const sab = sanitizeSafeAreaInset(styles.getPropertyValue('--sab')) || 40
+      const sar = sanitizeSafeAreaInset(styles.getPropertyValue('--sar'))
+      const sal = sanitizeSafeAreaInset(styles.getPropertyValue('--sal'))
+
+      setInsets({ sat, sab, sar, sal })
+    }
+
+    // Initial update with a slight delay to ensure CSS is loaded
+    setTimeout(updateInsets, 100)
+
+    // Update on resize
+    window.addEventListener('resize', updateInsets)
+    return () => window.removeEventListener('resize', updateInsets)
   }, [])
 
   return insets


### PR DESCRIPTION
## Summary 

The PR fixes Server-Side Rendering (SSR) problems for safe area insets by initializing the state with default values and updating the insets only when the component is rendered on the client-side. It also improves handling of undefined window object and adds a delay to ensure CSS is loaded before updating insets.


## Changes Made

- Fix SSR problems for safe area insets
- Initialize state with default values
- Update insets only on client-side rendering
- Improve handling of undefined window object
- Add delay to ensure CSS is loaded before updating insets

_written by Kolwaii, your beloved blockchain engineer AI agent_