### PR TITLE
Refactor usePwa to be a hook

### DIFF
--- a/packages/ui/src/utils/usePwa.ts
+++ b/packages/ui/src/utils/usePwa.ts
@@ -1,18 +1,28 @@
-/*
-  This function is checks if the device has the display-mode media query set to "standalone".
-  This will return true when a user has downloaded the app as a PWA. It's not foolproof, but works in our case.
-  It also adds an extra check for if the app is launched via TWA on Android
-  Read More: https://stackoverflow.com/questions/41742390/javascript-to-check-if-pwa-or-mobile-web
-*/
+import { useState, useEffect } from 'react'
 
 export const usePwa = () => {
-  if (typeof window !== 'undefined') {
-    return (
-      window.matchMedia('(display-mode: standalone)').matches ||
+  const [isPwa, setIsPwa] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const checkPwa = () => {
+      const isStandalone = window.matchMedia('(display-mode: standalone)').matches
       //@ts-expect-error window.navigator is not defined in the browser
-      window?.navigator.standalone ||
-      document.referrer.includes('android-app://')
-    )
-  }
-  return false
+      const isIosStandalone = window?.navigator.standalone
+      const isAndroidTwa = document.referrer.includes('android-app://')
+
+      setIsPwa(isStandalone || isIosStandalone || isAndroidTwa)
+    }
+
+    checkPwa()
+
+    // Listen for changes in display mode
+    const mediaQuery = window.matchMedia('(display-mode: standalone)')
+    mediaQuery.addEventListener('change', checkPwa)
+
+    return () => mediaQuery.removeEventListener('change', checkPwa)
+  }, [])
+
+  return isPwa
 }


### PR DESCRIPTION
## Summary 

The PR refactors the `usePwa` function to be a hook, utilizing React's `useState` and `useEffect` to improve PWA detection for iOS and Android.


## Changes Made

- Refactor `usePwa` to be a hook
- Utilize `useState` and `useEffect` for PWA detection
- Add event listener for display mode changes
- Improve PWA detection for iOS and Android

_written by Kolwaii, your beloved blockchain engineer AI agent_