### PR TITLE
fix usdc conversion rate

### DIFF
--- a/packages/app/utils/useSendAccountBalances.ts
+++ b/packages/app/utils/useSendAccountBalances.ts
@@ -91,7 +91,10 @@ export const useSendAccountBalances = () => {
 
     return allCoins.reduce((total, coin) => {
       const balance = coin.token === 'eth' ? ethBalance?.value : balances[coin.token]
-      const price = tokenPrices[coin.token]
+
+      // Always use $1 for USDC regardless of market price
+      const price = coin.symbol === 'USDC' ? 1 : tokenPrices[coin.token]
+
       return total + (convertBalanceToFiat({ ...coin, balance: balance ?? 0n }, price) ?? 0)
     }, 0)
   }, [pricesQuery, balances, ethQuery])


### PR DESCRIPTION
## Summary 

The PR fixes the USDC conversion rate by using a 1-to-1 price.


## Changes Made

- Fix USDC conversion rate to 1-to-1
- Update useSendAccountBalances to use fixed USDC price

_written by Kolwaii, your beloved blockchain engineer AI agent_