### PR TITLE
fix(playwright): more stable tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           done
           sleep 1
           echo tilt is ready
-          max_attempts=60
+          max_attempts=90
           wait_timeout=10
           for ((i=1; i<=max_attempts; i++)); do
             echo "Attempt $i: Waiting for tilt with timeout ${wait_timeout}s"

--- a/packages/playwright/tests/fixtures/profiles/test.ts
+++ b/packages/playwright/tests/fixtures/profiles/test.ts
@@ -14,8 +14,10 @@ export class ProfilePage {
 
   async visit(tag: string, expect?: Expect) {
     await this.page.goto(`/${tag}`)
-    const title = await this.page.title()
-    expect?.(title).toBe('Send | Profile')
+    await expect?.(async () => {
+      const title = await this.page.title()
+      expect?.(title).toBe('Send | Profile')
+    }).toPass()
     await expect?.(this.page.locator('#profileName')).toHaveText(this.profile.name)
   }
 }

--- a/packages/playwright/tests/fixtures/sendtags/checkout/page.ts
+++ b/packages/playwright/tests/fixtures/sendtags/checkout/page.ts
@@ -57,13 +57,13 @@ export class CheckoutPage {
       timeout: 10_000,
     })
     const signTransactionButton = this.page.getByRole('button', { name: 'complete purchase' })
-    expect?.(signTransactionButton).toBeEnabled({ timeout: 10_000 }) // blockchain stuff is a bit slow
+    await expect?.(signTransactionButton).toBeEnabled({ timeout: 20_000 }) // blockchain stuff is a bit slow
     await this.page.bringToFront()
     const errorButton = this.page.getByRole('button', { name: 'error' })
     expect?.(errorButton).toBeHidden()
     await this.page
       .getByRole('button', { name: 'loading' })
-      .waitFor({ state: 'detached', timeout: 10_000 })
+      .waitFor({ state: 'detached', timeout: 15_000 })
     await signTransactionButton.click()
     await confirmTagsRequest
     await confirmTagsResponse

--- a/packages/playwright/tests/profile.anon.spec.ts
+++ b/packages/playwright/tests/profile.anon.spec.ts
@@ -11,7 +11,10 @@ test.beforeAll(async () => {
   log = debug(`test:profile:anon:${test.info().parallelIndex}`)
 })
 
-const visitProfile = async ({ page, tag }: { page: Page; tag: string }) => page.goto(`/${tag}`)
+const visitProfile = async ({ page, tag }: { page: Page; tag: string }) => {
+  await page.goto(`/${tag}`)
+  await page.waitForURL(`/${tag}`)
+}
 
 test('anon user can visit public profile', async ({ page, seed }) => {
   const plan = await seed.users([userOnboarded])
@@ -22,8 +25,10 @@ test('anon user can visit public profile', async ({ page, seed }) => {
   assert(!!profile.name, 'profile name not found')
   assert(!!profile.about, 'profile about not found')
   await visitProfile({ page, tag: tag.name })
-  const title = await page.title()
-  expect(title).toBe('Send | Profile')
+  await expect(async () => {
+    const title = await page.title()
+    expect(title).toBe('Send | Profile')
+  }).toPass()
   await expect(page.getByText(profile.name)).toBeVisible()
   const profilePage = new ProfilePage(page, { name: profile.name, about: profile.about })
   await expect(profilePage.sendButton).toBeVisible()
@@ -34,8 +39,10 @@ test('anon user cannot visit private profile', async ({ page, seed }) => {
   const tag = plan.tags[0]
   assert(!!tag, 'tag not found')
   await visitProfile({ page, tag: tag.name })
-  const title = await page.title()
-  expect(title).toBe('404 | Send')
+  await expect(async () => {
+    const title = await page.title()
+    expect(title).toBe('404 | Send')
+  }).toPass()
   await expect(page.getByRole('heading', { name: 'Not found.' })).toBeVisible()
   await expect(page.getByRole('link', { name: 'Need to sign in?' })).toBeVisible()
 })

--- a/packages/playwright/tests/profile.logged-in.spec.ts
+++ b/packages/playwright/tests/profile.logged-in.spec.ts
@@ -24,14 +24,23 @@ test('logged in user needs onboarding before visiting profile', async ({ page, s
   assert(!!profile, 'profile not found')
   assert(!!profile.name, 'profile name not found')
   assert(!!profile.about, 'profile about not found')
+
   await page.goto(`${tag.name}`)
-  expect(await page.title()).toBe('Send | Onboarding')
+  await page.waitForURL(`${tag.name}`)
+
+  await expect(async () => {
+    expect(await page.title()).toBe('Send | Onboarding')
+  }).toPass()
+
   await new OnboardingPage(page).completeOnboarding(expect)
 
   // @todo check that user is redirected back to profile page
   await page.goto(`/profile/${profile.send_id}`)
+  await page.waitForURL(`/profile/${profile.send_id}`)
+  await expect(async () => {
+    expect(await page.title()).toBe('Send | Profile')
+  }).toPass()
   const profilePage = new ProfilePage(page, { name: profile.name, about: profile.about })
-  expect(await page.title()).toBe('Send | Profile')
   await expect(page.getByText(profile.name)).toBeVisible()
   await expect(profilePage.sendButton).toBeVisible()
 })

--- a/packages/playwright/tests/profile.onboarded.spec.ts
+++ b/packages/playwright/tests/profile.onboarded.spec.ts
@@ -57,7 +57,11 @@ test('can visit other user profile and send by tag', async ({ page, seed }) => {
 
   // can visit profile withouth the @ prefix
   await page.goto(`/${tag.name}`)
-  expect(await page.title()).toBe('Send | Profile')
+  await page.waitForURL(`/${tag.name}`)
+  await expect(async () => {
+    const title = await page.title()
+    expect(title).toBe('Send | Profile')
+  }).toPass()
   await expect(page.getByText(profile.name)).toBeVisible()
 })
 


### PR DESCRIPTION
## Summary 

This PR improves the stability of tests in the Playwright framework by introducing more robust expectations and waits. It also increases the timeout for waiting for Tilt to be ready in the CI workflow.


## Changes Made

- Improved test stability with more robust expectations
- Added waits for page URLs to ensure correct navigation
- Increased timeout for waiting for Tilt in CI workflow
- Updated test code to use async/await for better readability

_written by Kolwaii, your beloved blockchain engineer AI agent_