### PR TITLE
fix: Update Sendtag rewards and calculations to reflect new reward structure

### DIFF
--- a/packages/app/data/sendtags.test.ts
+++ b/packages/app/data/sendtags.test.ts
@@ -4,18 +4,18 @@ import { reward, total } from './sendtags'
 const decimals = 10n ** 6n
 
 const tags = [
-  { name: '1' }, // 16 USDC (12 USDC reward)
-  { name: '12' }, // 16 USDC (12 USDC reward)
-  { name: '123' }, // 16 USDC (12 USDC reward)
-  { name: '1234' }, // 8 USDC (6 USDC reward)
-  { name: '12345' }, // 4 USDC (3 USDC reward)
-  { name: '123456' }, // 2 USDC (1.5 USDC reward)
-  { name: '1234567' }, // 2 USDC (1.5 USDC reward)
+  { name: '1' }, // 16 USDC (4 USDC reward)
+  { name: '12' }, // 16 USDC (4 USDC reward)
+  { name: '123' }, // 16 USDC (4 USDC reward)
+  { name: '1234' }, // 8 USDC (2 USDC reward)
+  { name: '12345' }, // 4 USDC (1 USDC reward)
+  { name: '123456' }, // 2 USDC (.5 USDC reward)
+  { name: '1234567' }, // 2 USDC (.5 USDC reward)
 ]
 
 const totalDue = (16n + 16n + 16n + 8n + 4n + 2n + 2n) * decimals
 
-const rewardDue = BigInt(Math.round((12 + 12 + 12 + 6 + 3 + 1.5 + 1.5) * 10)) * (decimals / 10n)
+const rewardDue = BigInt(Math.round((4 + 4 + 4 + 2 + 1 + 0.5 + 0.5) * 10)) * (decimals / 10n)
 
 describe('Sendtag data', () => {
   it('can calculate total correctly', () => {

--- a/packages/app/data/sendtags.ts
+++ b/packages/app/data/sendtags.ts
@@ -34,21 +34,23 @@ export function price(length: number) {
 
 /**
  * Returns the referral reward for a Sendtag of the given length.
+ * The reward is 25% of the sendtag price.
+ *
  * @param length The length of the Sendtag.
  * @returns The referral reward for the Sendtag.
  */
 export function reward(length: number) {
   switch (length) {
     case 5:
-      return parseUnits('3', usdcCoin.decimals) // 3 USDC
+      return parseUnits('1', usdcCoin.decimals) // 1 USDC
     case 4:
-      return parseUnits('6', usdcCoin.decimals) // 6 USDC
+      return parseUnits('2', usdcCoin.decimals) // 8 USDC
     case 3:
     case 2:
     case 1:
-      return parseUnits('12', usdcCoin.decimals) // 12 USDC
+      return parseUnits('4', usdcCoin.decimals) // 4 USDC
     default:
-      return parseUnits('1.5', usdcCoin.decimals) // 1.5 USDC for 6+ characters
+      return parseUnits('.5', usdcCoin.decimals) // .50 USDC for 6+ characters
   }
 }
 


### PR DESCRIPTION
Affiliates now receive 25% of the sendtag total.
