### PR TITLE
add startWorkflow util for type safe args and ids

### DIFF
--- a/packages/workflows/src/utils/index.ts
+++ b/packages/workflows/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './bootstrap'
+export * from './startWorkflow'

--- a/packages/workflows/src/utils/startWorkflow.ts
+++ b/packages/workflows/src/utils/startWorkflow.ts
@@ -1,0 +1,28 @@
+import type { Client } from '@temporalio/client'
+import * as workflows from '../all-workflows'
+
+type WorkflowType = typeof workflows
+type WorkflowName = keyof WorkflowType
+
+type WorkflowArgs<T extends WorkflowName> = Parameters<WorkflowType[T]>
+
+type StartWorkflowParams<T extends WorkflowName> = {
+  client: Client
+  workflow: T
+  ids: [string, ...string[]] // non empty array
+  args: WorkflowArgs<T>
+}
+
+export async function startWorkflow<T extends WorkflowName>({
+  client,
+  workflow,
+  ids,
+  args,
+}: StartWorkflowParams<T>): Promise<ReturnType<Client['workflow']['start']>> {
+  //@ts-expect-error Mad about args actually being typed
+  return await client.workflow.start(workflows[workflow], {
+    taskQueue: 'monorepo',
+    workflowId: `temporal/${workflow}/${ids.join('/')}`,
+    args,
+  })
+}


### PR DESCRIPTION
adds a util function to make calling workflows more typesafe.

expects the function name as the id
