### PR TITLE
Lowercase token names on home page

### DIFF
--- a/packages/app/data/coins.ts
+++ b/packages/app/data/coins.ts
@@ -17,6 +17,7 @@ const BaseCoinSchema = z.object({
   symbol: z.string(),
   decimals: z.number().min(0).max(18),
   formatDecimals: z.number().min(0).optional(),
+  shortLabel: z.string().optional(),
   coingeckoTokenId: z.string(),
 })
 
@@ -102,6 +103,7 @@ export const morphoCoin = {
 
 export const aerodromeCoin = {
   label: 'Aerodrome Finance',
+  shortLabel: 'Aerodrome',
   symbol: 'AERO',
   token: aerodromeFinanceAddresses[baseMainnet.id],
   decimals: 18,
@@ -111,6 +113,7 @@ export const aerodromeCoin = {
 
 export const cbBtcCoin = {
   label: 'Coinbase Wrapped BTC',
+  shortLabel: 'cbBTC',
   symbol: 'CBBTC',
   token: coinbaseWrappedBtcAddresses[baseMainnet.id],
   decimals: 8,

--- a/packages/app/features/home/TokenBalanceList.tsx
+++ b/packages/app/features/home/TokenBalanceList.tsx
@@ -1,4 +1,4 @@
-import { Link, type LinkProps, Paragraph, useMedia, XStack } from '@my/ui'
+import { Link, type LinkProps, Paragraph, XStack } from '@my/ui'
 
 import { IconCoin } from 'app/components/icons/IconCoin'
 import type { CoinWithBalance } from 'app/data/coins'
@@ -41,19 +41,12 @@ const TokenBalanceItem = ({
   coin,
   ...props
 }: { coin: CoinWithBalance } & Omit<LinkProps, 'children'>) => {
-  const { gtMd } = useMedia()
-
   return (
     <Link display="flex" {...props}>
       <XStack gap={'$2'} $gtLg={{ gap: '$3.5' }} ai={'center'}>
         <IconCoin symbol={coin.symbol} />
-        <Paragraph
-          fontSize={'$5'}
-          fontWeight={'500'}
-          textTransform={'uppercase'}
-          color={'$color12'}
-        >
-          {coin.label.length > 15 && !gtMd ? coin.symbol : coin.label}
+        <Paragraph fontSize={'$5'} fontWeight={'500'} color={'$color12'}>
+          {coin.shortLabel || coin.label}
         </Paragraph>
       </XStack>
       <XStack gap={'$3.5'} ai={'center'}>

--- a/packages/app/features/home/TokenDetails.tsx
+++ b/packages/app/features/home/TokenDetails.tsx
@@ -57,13 +57,7 @@ export const TokenDetails = ({ coin }: { coin: CoinWithBalance }) => {
           <YStack gap="$4">
             <XStack ai={'center'} gap={'$3'}>
               <IconCoin size={'$2'} symbol={coin.symbol} />
-              <Paragraph
-                size={'$7'}
-                fontFamily={'$mono'}
-                col={'$color12'}
-                textTransform="uppercase"
-                fontWeight={'700'}
-              >
+              <Paragraph size={'$7'} fontFamily={'$mono'} col={'$color12'} fontWeight={'500'}>
                 {coin.label}
               </Paragraph>
             </XStack>

--- a/packages/app/features/home/__snapshots__/TokenDetails.test.tsx.snap
+++ b/packages/app/features/home/__snapshots__/TokenDetails.test.tsx.snap
@@ -182,9 +182,8 @@ exports[`TokenDetails renders correctly 1`] = `
                 "color": "#FFFFFF",
                 "fontFamily": "System",
                 "fontSize": 24,
-                "fontWeight": "700",
+                "fontWeight": "500",
                 "lineHeight": 25,
-                "textTransform": "uppercase",
                 "userSelect": "auto",
               }
             }


### PR DESCRIPTION
## Summary 

The PR introduces a new optional field `shortLabel` to the coin schema, and updates the token labels to use the `shortLabel` if available. It also removes the uppercase transformation from the token labels.


## Changes Made

- Added `shortLabel` field to coin schema
- Updated token labels to use `shortLabel` if available
- Removed uppercase transformation from token labels
- Updated coin data with `shortLabel` values

_written by Kolwaii, your beloved blockchain engineer AI agent_