### PR TITLE
Add quick actions on home screen on mobile

### DIFF
--- a/packages/app/components/MobileButtonRowLayout.tsx
+++ b/packages/app/components/MobileButtonRowLayout.tsx
@@ -95,21 +95,15 @@ const Home = ({ children, ...props }: XStackProps) => {
                   return null
                 case selectedCoin !== undefined:
                   return (
-                    <Stack f={1} $gtSm={{ w: '50%' }} flexDirection="row-reverse" maw={350}>
+                    <Stack f={1} $gtSm={{ maw: 350 }}>
                       <HomeButtons.SendButton />
                     </Stack>
                   )
                 default:
                   return (
-                    <>
-                      <Stack f={1} w="50%" flexDirection="row-reverse" maw={350}>
-                        <HomeButtons.GhostDepositButton />
-                      </Stack>
-
-                      <Stack f={1} w="50%" jc={'center'} maw={350}>
-                        <HomeButtons.SendButton />
-                      </Stack>
-                    </>
+                    <Stack f={1} $gtSm={{ maw: 350 }}>
+                      <HomeButtons.SendButton />
+                    </Stack>
                   )
               }
             })()}

--- a/packages/app/features/home/HomeQuickActions.tsx
+++ b/packages/app/features/home/HomeQuickActions.tsx
@@ -1,0 +1,65 @@
+import { Button, LinkableButton, Theme, XStack, YStack, type XStackProps } from '@my/ui'
+import { IconPlus, IconSwap } from 'app/components/icons'
+import { useHoverStyles } from 'app/utils/useHoverStyles'
+import { sendCoin, usdcCoin } from 'app/data/coins'
+import { useCoinFromTokenParam } from 'app/utils/useCoinFromTokenParam'
+
+export const HomeQuickActions = (props: XStackProps) => {
+  const { coin } = useCoinFromTokenParam()
+  const hoverStyles = useHoverStyles()
+
+  const getTradeUrl = () => {
+    if (!coin) {
+      return '/trade'
+    }
+
+    if (coin.symbol === sendCoin.symbol) {
+      return `/trade?inToken=${coin.token}&outToken=${usdcCoin.token}`
+    }
+
+    return `/trade?inToken=${coin.token}`
+  }
+
+  return (
+    <XStack w={'100%'} gap={'$3.5'} $gtLg={{ gap: '$5' }} {...props}>
+      <LinkableButton
+        href="/deposit"
+        f={1}
+        height={'auto'}
+        hoverStyle={hoverStyles}
+        focusStyle={hoverStyles}
+      >
+        <YStack gap="$2" jc={'space-between'} ai="center" p="$4">
+          <IconPlus
+            size={'$1.5'}
+            $theme-dark={{ color: '$primary' }}
+            $theme-light={{ color: '$color12' }}
+          />
+          <Button.Text fontSize={'$4'} px="$2">
+            Deposit
+          </Button.Text>
+        </YStack>
+      </LinkableButton>
+      <LinkableButton
+        href={getTradeUrl()}
+        f={1}
+        height={'auto'}
+        hoverStyle={hoverStyles}
+        focusStyle={hoverStyles}
+      >
+        <YStack gap="$2" jc={'space-between'} ai="center" p="$4" height={'auto'}>
+          <Theme name="green">
+            <IconSwap
+              size={'$1'}
+              $theme-dark={{ color: '$primary' }}
+              $theme-light={{ color: '$color12' }}
+            />
+          </Theme>
+          <Button.Text fontSize={'$4'} px="$2">
+            Trade
+          </Button.Text>
+        </YStack>
+      </LinkableButton>
+    </XStack>
+  )
+}

--- a/packages/app/features/home/TokenDetails.test.tsx
+++ b/packages/app/features/home/TokenDetails.test.tsx
@@ -23,6 +23,17 @@ jest.mock('app/utils/useTokenPrices', () => ({
   }),
 }))
 
+jest.mock('app/utils/useCoinFromTokenParam', () => ({
+  useCoinFromTokenParam: jest.fn().mockReturnValue({
+    coin: {
+      label: 'USDC',
+      token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      balance: 250000n,
+    },
+    isLoading: false,
+  }),
+}))
+
 describe('TokenDetails', () => {
   beforeEach(() => {
     jest.useFakeTimers()

--- a/packages/app/features/home/TokenDetails.tsx
+++ b/packages/app/features/home/TokenDetails.tsx
@@ -1,58 +1,19 @@
-import {
-  AnimatePresence,
-  Button,
-  Card,
-  LinkableButton,
-  Paragraph,
-  Separator,
-  Spinner,
-  Stack,
-  Theme,
-  XStack,
-  YStack,
-} from '@my/ui'
-import { type CoinWithBalance, sendCoin, usdcCoin } from 'app/data/coins'
+import { Card, Paragraph, Separator, Spinner, Stack, Theme, XStack, YStack } from '@my/ui'
+import type { CoinWithBalance } from 'app/data/coins'
 import { ArrowDown, ArrowUp } from '@tamagui/lucide-icons'
-import { IconError, IconPlus, IconSwap } from 'app/components/icons'
+import { IconError } from 'app/components/icons'
 import { useTokenMarketData } from 'app/utils/coin-gecko'
 import formatAmount from 'app/utils/formatAmount'
 import { TokenActivity } from './TokenActivity'
 import { useTokenPrices } from 'app/utils/useTokenPrices'
 import { convertBalanceToFiat } from 'app/utils/convertBalanceToUSD'
 import { IconCoin } from 'app/components/icons/IconCoin'
-import { useHoverStyles } from 'app/utils/useHoverStyles'
-
-export function AnimateEnter({ children }: { children: React.ReactNode }) {
-  return (
-    <AnimatePresence>
-      <Stack
-        key="enter"
-        animateOnly={['transform', 'opacity']}
-        animation="200ms"
-        enterStyle={{ opacity: 0, scale: 0.9 }}
-        exitStyle={{ opacity: 0, scale: 0.95 }}
-        opacity={1}
-      >
-        {children}
-      </Stack>
-    </AnimatePresence>
-  )
-}
+import { HomeQuickActions } from 'app/features/home/HomeQuickActions'
 
 export const TokenDetails = ({ coin }: { coin: CoinWithBalance }) => {
-  const hoverStyles = useHoverStyles()
-
-  const getTradeUrl = () => {
-    if (coin?.symbol === sendCoin.symbol) {
-      return `/trade?inToken=${coin?.token}&outToken=${usdcCoin.token}`
-    }
-
-    return `/trade?inToken=${coin?.token}`
-  }
-
   return (
     <YStack f={1} gap="$5" $gtLg={{ w: '45%', pb: '$0' }} pb="$5">
-      <YStack gap="$5">
+      <YStack gap="$3.5" $gtLg={{ gap: '$5' }}>
         <Card p="$4.5" w={'100%'} jc={'space-between'} $gtLg={{ h: 244, p: '$6' }}>
           <YStack gap="$4">
             <XStack ai={'center'} gap={'$3'}>
@@ -74,46 +35,7 @@ export const TokenDetails = ({ coin }: { coin: CoinWithBalance }) => {
             </YStack>
           </YStack>
         </Card>
-        <XStack w={'100%'} gap={'$5'}>
-          <LinkableButton
-            href="/deposit"
-            f={1}
-            height={'auto'}
-            hoverStyle={hoverStyles}
-            focusStyle={hoverStyles}
-          >
-            <YStack gap="$2" jc={'space-between'} ai="center" p="$4">
-              <IconPlus
-                size={'$1.5'}
-                $theme-dark={{ color: '$primary' }}
-                $theme-light={{ color: '$color12' }}
-              />
-              <Button.Text fontSize={'$4'} px="$2">
-                Deposit
-              </Button.Text>
-            </YStack>
-          </LinkableButton>
-          <LinkableButton
-            href={getTradeUrl()}
-            f={1}
-            height={'auto'}
-            hoverStyle={hoverStyles}
-            focusStyle={hoverStyles}
-          >
-            <YStack gap="$2" jc={'space-between'} ai="center" p="$4" height={'auto'}>
-              <Theme name="green">
-                <IconSwap
-                  size={'$1'}
-                  $theme-dark={{ color: '$primary' }}
-                  $theme-light={{ color: '$color12' }}
-                />
-              </Theme>
-              <Button.Text fontSize={'$4'} px="$2">
-                Trade
-              </Button.Text>
-            </YStack>
-          </LinkableButton>
-        </XStack>
+        <HomeQuickActions />
       </YStack>
       <YStack gap={'$3'}>
         <TokenActivity coin={coin} />

--- a/packages/app/features/home/__snapshots__/TokenDetails.test.tsx.snap
+++ b/packages/app/features/home/__snapshots__/TokenDetails.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TokenDetails renders correctly 1`] = `
     style={
       {
         "flexDirection": "column",
-        "gap": 24,
+        "gap": 16,
       }
     }
   >
@@ -232,7 +232,7 @@ exports[`TokenDetails renders correctly 1`] = `
       style={
         {
           "flexDirection": "row",
-          "gap": 24,
+          "gap": 16,
           "width": "100%",
         }
       }

--- a/packages/app/features/home/screen.tsx
+++ b/packages/app/features/home/screen.tsx
@@ -24,6 +24,7 @@ import { useRootScreenParams } from 'app/routers/params'
 import { HomeButtons } from './HomeButtons'
 import { AlertCircle } from '@tamagui/lucide-icons'
 import { useIsSendingUnlocked } from 'app/utils/useIsSendingUnlocked'
+import { HomeQuickActions } from 'app/features/home/HomeQuickActions'
 
 function SendSearchBody() {
   const { isLoading, error } = useTagSearch()
@@ -64,7 +65,7 @@ function HomeBody(props: XStackProps) {
         $gtLg={{ display: 'flex', w: '45%', gap: '$5', pb: 0 }}
         display={!selectedCoin ? 'flex' : 'none'}
         width="100%"
-        gap="$5"
+        gap="$3.5"
         ai={'center'}
         pb={Math.max(bottom, 24) + 72} // add mobile bottom button row + 24px
       >
@@ -92,6 +93,7 @@ function HomeBody(props: XStackProps) {
         ) : (
           <TokenBalanceCard />
         )}
+        <HomeQuickActions $gtLg={{ display: 'none' }} />
         <YStack w={'100%'} ai={'center'}>
           <Card
             bc={'$color1'}


### PR DESCRIPTION
## Summary 

The PR introduces a new component `HomeQuickActions` that provides quick actions on the home screen for mobile devices. It includes two buttons for deposit and trade. The component is used in `TokenDetails` and `HomeBody` components. The PR also refactors the existing code to remove duplicated logic and improve the user experience.


## Changes Made

- Added `HomeQuickActions` component
- Refactored `TokenDetails` component
- Updated `HomeBody` component
- Removed duplicated logic
- Improved user experience

_written by Kolwaii, your beloved blockchain engineer AI agent_