### PR TITLE
Aligned menu icons on desktop

### DIFF
--- a/packages/app/components/sidebar/HomeSideBar.tsx
+++ b/packages/app/components/sidebar/HomeSideBar.tsx
@@ -15,7 +15,7 @@ import {
 import { baseMainnet } from '@my/wagmi/chains'
 import {
   IconAccount,
-  IconActivity,
+  IconArrowUp,
   IconChart,
   IconDeviceReset,
   IconHome,
@@ -34,12 +34,12 @@ import { useHoverStyles } from 'app/utils/useHoverStyles'
 
 const links = [
   {
-    icon: <IconHome size={'$1.75'} color={'inherit'} />,
+    icon: <IconHome size={'$1'} color={'inherit'} scale={'1.2'} />,
     text: 'Home',
     href: '/',
   },
   {
-    icon: <IconActivity size={'$1'} color={'inherit'} />,
+    icon: <IconArrowUp size={'$1'} color={'inherit'} scale={'1.3'} />,
     text: 'Send',
     href: '/send',
   },
@@ -59,12 +59,12 @@ const links = [
     href: '/invest',
   },
   {
-    icon: <IconDeviceReset size={'$1'} color={'inherit'} />,
+    icon: <IconDeviceReset size={'$1'} color={'inherit'} scale={'1.2'} />,
     text: 'Activity',
     href: '/activity',
   },
   {
-    icon: <IconAccount size={'$1'} color={'inherit'} />,
+    icon: <IconAccount size={'$1'} color={'inherit'} scale={'1.3'} />,
     text: 'Account',
     href: '/account',
   },


### PR DESCRIPTION
## Summary 

The PR updates the sidebar menu icons on desktop, replacing some icons and adjusting their sizes and scales.


## Changes Made

- Replaced `IconActivity` with `IconArrowUp`
- Updated icon sizes and scales for better alignment
- Changed `IconHome` size to `$1` and scale to `1.2`
- Added scale to `IconArrowUp`, `IconDeviceReset`, and `IconAccount`

_written by Kolwaii, your beloved blockchain engineer AI agent_