### PR TITLE
Fixed 'withdraw' word show for trades instead of trade in activity

### DIFF
--- a/packages/app/features/activity/ActivityDetails.tsx
+++ b/packages/app/features/activity/ActivityDetails.tsx
@@ -41,7 +41,7 @@ export const ActivityDetails = ({
 } & StackProps) => {
   const { data: swapRouters } = useSwapRouters()
   const { data: liquidityPools } = useLiquidityPools()
-  const activityEventName = useEventNameFromActivity({ activity, swapRouters })
+  const activityEventName = useEventNameFromActivity({ activity, swapRouters, liquidityPools })
   const activityPhrase = usePhraseFromActivity({ activity, swapRouters, liquidityPools })
   const subText = useSubtextFromActivity({ activity, swapRouters, liquidityPools })
   const amount = useAmountFromActivity(activity)
@@ -87,7 +87,9 @@ export const ActivityDetails = ({
                       default:
                         return <Text>{subText}</Text>
                     }
-                  })()} {(() => {
+                  })()}
+                  &nbsp;
+                  {(() => {
                     switch (true) {
                       case isSendtagCheckoutEvent(activity):
                         return (

--- a/packages/app/features/home/TokenActivityRow.tsx
+++ b/packages/app/features/home/TokenActivityRow.tsx
@@ -28,7 +28,7 @@ export function TokenActivityRow({
   const { created_at, from_user, to_user } = activity
   const amount = useAmountFromActivity(activity, swapRouters, liquidityPools)
   const date = CommentsTime(new Date(created_at))
-  const eventName = useEventNameFromActivity({ activity, swapRouters })
+  const eventName = useEventNameFromActivity({ activity, swapRouters, liquidityPools })
   const subtext = useSubtextFromActivity({ activity, swapRouters, liquidityPools })
   const isERC20Transfer = isSendAccountTransfersEvent(activity)
   const isETHReceive = isSendAccountReceiveEvent(activity)

--- a/packages/app/utils/activity.ts
+++ b/packages/app/utils/activity.ts
@@ -303,7 +303,11 @@ export function eventNameFromActivity({
   activity,
   swapRouters = [],
   liquidityPools = [],
-}: { activity: Activity; swapRouters?: SwapRouter[]; liquidityPools?: LiquidityPool[] }): string {
+}: {
+  activity: Activity
+  swapRouters?: SwapRouter[]
+  liquidityPools?: LiquidityPool[]
+}): string {
   const { event_name, from_user, to_user, data } = activity
   const isERC20Transfer = isSendAccountTransfersEvent(activity)
   const isETHReceive = isSendAccountReceiveEvent(activity)
@@ -363,12 +367,19 @@ export function eventNameFromActivity({
 /**
  * Returns the human readable event name of the activity.
  * @param activity
+ * @param swapRouters - Optional list of swap routers to validate the activity against.
+ * @param liquidityPools - Optional list of liquidity pools to validate the activity against.
  * @returns the human readable event name of the activity
  */
 export function useEventNameFromActivity({
   activity,
   swapRouters = [],
-}: { activity: Activity; swapRouters?: SwapRouter[] }): string {
+  liquidityPools = [],
+}: {
+  activity: Activity
+  swapRouters?: SwapRouter[]
+  liquidityPools?: LiquidityPool[]
+}): string {
   const isERC20Transfer = isSendAccountTransfersEvent(activity)
   const { data: addressBook } = useAddressBook()
 
@@ -386,8 +397,8 @@ export function useEventNameFromActivity({
       return 'Withdraw'
     }
     // this should have always been a hook
-    return eventNameFromActivity({ activity, swapRouters })
-  }, [activity, addressBook, isERC20Transfer, swapRouters])
+    return eventNameFromActivity({ activity, swapRouters, liquidityPools })
+  }, [activity, addressBook, isERC20Transfer, swapRouters, liquidityPools])
 }
 
 /**
@@ -401,7 +412,11 @@ export function phraseFromActivity({
   activity,
   swapRouters = [],
   liquidityPools = [],
-}: { activity: Activity; swapRouters?: SwapRouter[]; liquidityPools?: LiquidityPool[] }): string {
+}: {
+  activity: Activity
+  swapRouters?: SwapRouter[]
+  liquidityPools?: LiquidityPool[]
+}): string {
   const { event_name, from_user, to_user, data } = activity
   const isERC20Transfer = isSendAccountTransfersEvent(activity)
   const isETHReceive = isSendAccountReceiveEvent(activity)
@@ -458,13 +473,19 @@ export function phraseFromActivity({
 /**
  * Returns the phrase for event name of the activity for activity details.
  * @param activity
+ * @param swapRouters - Optional list of swap routers to validate the activity against.
+ * @param liquidityPools - Optional list of liquidity pools to validate the activity against.
  * @returns the phrase for event name of the activity for activity details
  */
 export function usePhraseFromActivity({
   activity,
   swapRouters = [],
   liquidityPools = [],
-}: { activity: Activity; swapRouters?: SwapRouter[]; liquidityPools?: LiquidityPool[] }): string {
+}: {
+  activity: Activity
+  swapRouters?: SwapRouter[]
+  liquidityPools?: LiquidityPool[]
+}): string {
   const isERC20Transfer = isSendAccountTransfersEvent(activity)
   const { data: addressBook } = useAddressBook()
   const isSendEarnDeposit = isSendEarnDepositEvent(activity)
@@ -494,9 +515,11 @@ export function subtextFromActivity({
   activity,
   swapRouters = [],
   liquidityPools = [],
-}: { activity: Activity; swapRouters?: SwapRouter[]; liquidityPools?: LiquidityPool[] }):
-  | string
-  | null {
+}: {
+  activity: Activity
+  swapRouters?: SwapRouter[]
+  liquidityPools?: LiquidityPool[]
+}): string | null {
   const _user = counterpart(activity)
   const { from_user, to_user, data } = activity
   const isERC20Transfer = isSendAccountTransfersEvent(activity)


### PR DESCRIPTION
## Summary 

The PR enhances the activity details and token activity row by adding liquidity pools to the useEventNameFromActivity and usePhraseFromActivity functions.


## Changes Made

- Added liquidityPools to useEventNameFromActivity and usePhraseFromActivity
- Updated ActivityDetails and TokenActivityRow to use the new functions
- Improved event name and phrase handling for activities

_written by Kolwaii, your beloved blockchain engineer AI agent_