### PR TITLE
Added back swap routers part of seeder

### DIFF
--- a/packages/snaplet/bin/seed.ts
+++ b/packages/snaplet/bin/seed.ts
@@ -8,6 +8,8 @@ import { createSeedClient } from '@snaplet/seed'
 import { models } from '../src'
 import { leaderboardReferralsAllTimes, userOnboarded } from '../src/models'
 import { pravatar } from '../src/utils'
+import { baseMainnetClient } from '@my/wagmi'
+import { hexToBytes } from 'viem'
 
 const dryRun = process.env.DRY !== '0'
 
@@ -30,6 +32,13 @@ await seed.$resetDatabase(
 )
 
 console.log('Snaplet seeding database.')
+
+await seed.swap_routers([
+  {
+    router_addr: Buffer.from(hexToBytes('0xc7d3ab410d49b664d03fe5b1038852ac852b1b29')),
+    chain_id: baseMainnetClient.chain.id,
+  },
+])
 
 await seed.users([
   {


### PR DESCRIPTION
## Summary 

Added back swap routers part of seeder, including mainnet client and hex to bytes conversion.


## Changes Made

- Added swap routers to seeder
- Imported mainnet client and hex to bytes conversion utility
- Updated seed function to include swap routers

_written by Kolwaii, your beloved blockchain engineer AI agent_