### PR TITLE
Put settings pages behind bottom nav bar

### DIFF
--- a/packages/app/features/account/settings/layout.web.tsx
+++ b/packages/app/features/account/settings/layout.web.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, XStack } from '@my/ui'
+import { ScrollView, useMedia, XStack, YStack } from '@my/ui'
 import { SettingsLinks } from './SettingsLinks'
 import type { ReactNode } from 'react'
 
@@ -7,29 +7,37 @@ export type SettingsLayoutProps = {
 }
 
 export const SettingsLayout = ({ children }: SettingsLayoutProps) => {
+  const media = useMedia()
+
+  if (media.gtLg) {
+    return <DesktopSettingsLayout>{children}</DesktopSettingsLayout>
+  }
+
+  return <MobileSettingsLayout>{children}</MobileSettingsLayout>
+}
+
+const DesktopSettingsLayout = ({ children }: SettingsLayoutProps) => {
   return (
     <XStack w={'100%'} gap={'$3.5'} pb={'$3.5'}>
-      <ScrollView
-        testID={'settings-links'}
-        showsVerticalScrollIndicator={false}
-        display={children ? 'none' : 'flex'}
-        $gtLg={{
-          display: 'flex',
-          maxWidth: '49%',
-        }}
-      >
+      <ScrollView testID={'settings-links'} showsVerticalScrollIndicator={false} maxWidth={'49%'}>
         <SettingsLinks />
       </ScrollView>
-      <ScrollView
-        testID={'settings-links'}
-        showsVerticalScrollIndicator={false}
-        display={children ? 'flex' : 'none'}
-        $gtLg={{
-          maxWidth: '49%',
-        }}
-      >
+      <ScrollView testID={'settings-links'} showsVerticalScrollIndicator={false} maxWidth={'49%'}>
         {children}
       </ScrollView>
+    </XStack>
+  )
+}
+
+const MobileSettingsLayout = ({ children }: SettingsLayoutProps) => {
+  return (
+    <XStack w={'100%'} gap={'$3.5'} pb={'$3.5'}>
+      <YStack w={'100%'} testID={'settings-links'} display={children ? 'none' : 'flex'}>
+        <SettingsLinks />
+      </YStack>
+      <YStack w={'100%'} testID={'settings-links'} display={children ? 'flex' : 'none'}>
+        {children}
+      </YStack>
     </XStack>
   )
 }


### PR DESCRIPTION
## Summary 

The PR introduces a new layout for settings pages, with separate layouts for desktop and mobile devices, using media queries to determine the layout.


## Changes Made

- Added desktop and mobile settings layouts
- Used media query to determine layout
- Created separate components for desktop and mobile layouts

_written by Kolwaii, your beloved blockchain engineer AI agent_