### PR TITLE
Fixed edit button not always working on trade page

### DIFF
--- a/packages/app/features/swap/summary/__snapshots__/screen.test.tsx.snap
+++ b/packages/app/features/swap/summary/__snapshots__/screen.test.tsx.snap
@@ -242,6 +242,7 @@ exports[`swap summary screen should render 1`] = `
                 disabled={false}
                 focusVisibleStyle={{}}
                 focusable={[Function]}
+                hitSlop={[Function]}
                 minPressDuration={0}
                 onBlur={[Function]}
                 onFocus={[Function]}
@@ -256,8 +257,8 @@ exports[`swap summary screen should render 1`] = `
                     "alignItems": "center",
                     "backgroundColor": "transparent",
                     "borderBottomColor": "transparent",
-                    "borderBottomLeftRadius": 16,
-                    "borderBottomRightRadius": 16,
+                    "borderBottomLeftRadius": 0,
+                    "borderBottomRightRadius": 0,
                     "borderBottomWidth": 0,
                     "borderLeftColor": "transparent",
                     "borderLeftWidth": 0,
@@ -265,8 +266,8 @@ exports[`swap summary screen should render 1`] = `
                     "borderRightWidth": 0,
                     "borderStyle": "solid",
                     "borderTopColor": "transparent",
-                    "borderTopLeftRadius": 16,
-                    "borderTopRightRadius": 16,
+                    "borderTopLeftRadius": 0,
+                    "borderTopRightRadius": 0,
                     "borderTopWidth": 0,
                     "flexDirection": "row",
                     "flexWrap": "nowrap",
@@ -536,6 +537,7 @@ exports[`swap summary screen should render 1`] = `
                 disabled={false}
                 focusVisibleStyle={{}}
                 focusable={[Function]}
+                hitSlop={[Function]}
                 minPressDuration={0}
                 onBlur={[Function]}
                 onFocus={[Function]}
@@ -550,8 +552,8 @@ exports[`swap summary screen should render 1`] = `
                     "alignItems": "center",
                     "backgroundColor": "transparent",
                     "borderBottomColor": "transparent",
-                    "borderBottomLeftRadius": 16,
-                    "borderBottomRightRadius": 16,
+                    "borderBottomLeftRadius": 0,
+                    "borderBottomRightRadius": 0,
                     "borderBottomWidth": 0,
                     "borderLeftColor": "transparent",
                     "borderLeftWidth": 0,
@@ -559,8 +561,8 @@ exports[`swap summary screen should render 1`] = `
                     "borderRightWidth": 0,
                     "borderStyle": "solid",
                     "borderTopColor": "transparent",
-                    "borderTopLeftRadius": 16,
-                    "borderTopRightRadius": 16,
+                    "borderTopLeftRadius": 0,
+                    "borderTopRightRadius": 0,
                     "borderTopWidth": 0,
                     "flexDirection": "row",
                     "flexWrap": "nowrap",

--- a/packages/app/features/swap/summary/screen.tsx
+++ b/packages/app/features/swap/summary/screen.tsx
@@ -402,8 +402,10 @@ export const EditButton = () => {
       focusStyle={{ backgroundColor: 'transparent' }}
       p={0}
       bw={0}
+      br={0}
       height={'auto'}
       onPress={handlePress}
+      hitSlop={20}
     >
       <Button.Text size={'$5'} hoverStyle={{ color: '$primary' }}>
         edit


### PR DESCRIPTION
## Summary 

Fixed edit button functionality on trade page by adjusting button styles and adding hitSlop.


## Changes Made

- Added hitSlop to EditButton for better press detection
- Removed border radius from EditButton

_written by Kolwaii, your beloved blockchain engineer AI agent_