### PR TITLE
Fixed settings edit pages width on desktop

### DIFF
--- a/packages/app/features/account/components/editProfile/screen.tsx
+++ b/packages/app/features/account/components/editProfile/screen.tsx
@@ -166,6 +166,11 @@ function EditProfileForm({ profile, onSave }: { profile: Tables<'profiles'>; onS
         about: about ? about : '',
         isPublic: is_public !== null ? is_public : true,
       }}
+      formProps={{
+        $gtSm: {
+          maxWidth: '100%',
+        },
+      }}
       onSubmit={handleSubmit}
       renderAfter={({ submit }) => (
         <YStack>

--- a/packages/app/features/account/settings/personal-info.tsx
+++ b/packages/app/features/account/settings/personal-info.tsx
@@ -147,6 +147,11 @@ export const PersonalInfoScreen = () => {
           disabled: Boolean(profile?.birthday),
         },
       }}
+      formProps={{
+        $gtSm: {
+          maxWidth: '100%',
+        },
+      }}
       renderAfter={({ submit }) => (
         <YStack>
           <SubmitButton


### PR DESCRIPTION
## Summary 

Fixed settings edit pages width on desktop by adding formProps to limit maxWidth.


## Changes Made

- Added formProps to EditProfileForm
- Added formProps to PersonalInfoScreen
- Set maxWidth to 100% for screens greater than small

_written by Kolwaii, your beloved blockchain engineer AI agent_