### PR TITLE
Aligned desktop home page with mobile

### DIFF
--- a/packages/app/features/home/HomeQuickActions.tsx
+++ b/packages/app/features/home/HomeQuickActions.tsx
@@ -1,10 +1,12 @@
 import { Button, LinkableButton, Theme, XStack, YStack, type XStackProps } from '@my/ui'
-import { IconPlus, IconSwap } from 'app/components/icons'
+import { IconArrowUp, IconPlus, IconSwap } from 'app/components/icons'
 import { useHoverStyles } from 'app/utils/useHoverStyles'
 import { sendCoin, usdcCoin } from 'app/data/coins'
 import { useCoinFromTokenParam } from 'app/utils/useCoinFromTokenParam'
 
-export const HomeQuickActions = (props: XStackProps) => {
+type HomeQuickActionsProps = XStackProps & { showSendAction?: boolean }
+
+export const HomeQuickActions = ({ showSendAction, ...props }: HomeQuickActionsProps) => {
   const { coin } = useCoinFromTokenParam()
   const hoverStyles = useHoverStyles()
 
@@ -20,8 +22,36 @@ export const HomeQuickActions = (props: XStackProps) => {
     return `/trade?inToken=${coin.token}`
   }
 
+  const getSendUrl = () => {
+    if (!coin) {
+      return '/send'
+    }
+
+    return `/send?sendToken=${coin.token}`
+  }
+
   return (
     <XStack w={'100%'} gap={'$3.5'} $gtLg={{ gap: '$5' }} {...props}>
+      {showSendAction && (
+        <LinkableButton
+          href={getSendUrl()}
+          f={1}
+          height={'auto'}
+          hoverStyle={hoverStyles}
+          focusStyle={hoverStyles}
+        >
+          <YStack gap="$2" jc={'space-between'} ai="center" px="$4" py="$3.5" $gtSm={{ py: '$4' }}>
+            <IconArrowUp
+              size={'$1.5'}
+              $theme-dark={{ color: '$primary' }}
+              $theme-light={{ color: '$color12' }}
+            />
+            <Button.Text fontSize={'$5'} px="$2">
+              Send
+            </Button.Text>
+          </YStack>
+        </LinkableButton>
+      )}
       <LinkableButton
         href="/deposit"
         f={1}

--- a/packages/app/features/home/TokenDetails.test.tsx
+++ b/packages/app/features/home/TokenDetails.test.tsx
@@ -33,6 +33,10 @@ jest.mock('app/utils/useCoinFromTokenParam', () => ({
   }),
 }))
 
+jest.mock('app/utils/useIsSendingUnlocked', () => ({
+  useIsSendingUnlocked: jest.fn().mockReturnValue(true),
+}))
+
 describe('TokenDetails', () => {
   beforeEach(() => {
     jest.useFakeTimers()

--- a/packages/app/features/home/TokenDetails.tsx
+++ b/packages/app/features/home/TokenDetails.tsx
@@ -1,4 +1,4 @@
-import { Card, Paragraph, Separator, Spinner, Stack, Theme, XStack, YStack } from '@my/ui'
+import { Card, Paragraph, Separator, Spinner, Stack, Theme, useMedia, XStack, YStack } from '@my/ui'
 import type { allCoins, CoinWithBalance } from 'app/data/coins'
 import { ArrowDown, ArrowUp } from '@tamagui/lucide-icons'
 import { IconCoin, IconError } from 'app/components/icons'
@@ -8,8 +8,12 @@ import formatAmount from 'app/utils/formatAmount'
 import { useTokenPrices } from 'app/utils/useTokenPrices'
 import { TokenActivity } from './TokenActivity'
 import { HomeQuickActions } from 'app/features/home/HomeQuickActions'
+import { useIsSendingUnlocked } from 'app/utils/useIsSendingUnlocked'
 
 export const TokenDetails = ({ coin }: { coin: CoinWithBalance }) => {
+  const media = useMedia()
+  const { isSendingUnlocked } = useIsSendingUnlocked()
+
   return (
     <YStack f={1} gap="$5" $gtLg={{ w: '45%', pb: '$0' }} pb="$5">
       <YStack gap="$3.5" $gtLg={{ gap: '$5' }}>
@@ -34,7 +38,7 @@ export const TokenDetails = ({ coin }: { coin: CoinWithBalance }) => {
             </YStack>
           </YStack>
         </Card>
-        <HomeQuickActions />
+        <HomeQuickActions showSendAction={media.gtLg && isSendingUnlocked} />
       </YStack>
       <YStack gap={'$3'}>
         <TokenActivity coin={coin} />

--- a/packages/app/features/home/screen.tsx
+++ b/packages/app/features/home/screen.tsx
@@ -49,6 +49,7 @@ function SendSearchBody() {
 function HomeBody(props: XStackProps) {
   const { coin: selectedCoin } = useCoinFromTokenParam()
   const { isSendingUnlocked, isLoading } = useIsSendingUnlocked()
+  const quickActionHeightWithOffset = 117
 
   if (isLoading)
     return (
@@ -58,7 +59,13 @@ function HomeBody(props: XStackProps) {
     )
 
   return (
-    <XStack w={'100%'} $gtLg={{ gap: '$5' }} $lg={{ f: 1, pt: '$3' }} minHeight={'100%'} {...props}>
+    <XStack
+      w={'100%'}
+      $gtLg={{ gap: '$5', pb: '$3.5' }}
+      $lg={{ f: 1, pt: '$3' }}
+      minHeight={'100%'}
+      {...props}
+    >
       <YStack
         $gtLg={{ display: 'flex', w: '45%', gap: '$5', pb: 0 }}
         display={!selectedCoin ? 'flex' : 'none'}
@@ -90,8 +97,19 @@ function HomeBody(props: XStackProps) {
         ) : (
           <TokenBalanceCard />
         )}
-        <HomeQuickActions $gtLg={{ display: 'none' }} />
-        <YStack w={'100%'} ai={'center'}>
+        <HomeQuickActions
+          y={selectedCoin ? -quickActionHeightWithOffset : 0}
+          zIndex={selectedCoin ? -1 : 0}
+          animateOnly={['transform']}
+          animation="200ms"
+        />
+        <YStack
+          w={'100%'}
+          ai={'center'}
+          y={selectedCoin ? -quickActionHeightWithOffset : 0}
+          animateOnly={['transform']}
+          animation="200ms"
+        >
           <Card
             bc={'$color1'}
             width="100%"
@@ -99,27 +117,11 @@ function HomeBody(props: XStackProps) {
             $gtSm={{
               p: '$4',
             }}
-            $gtLg={{
-              maxHeight: 370,
-              // @ts-expect-error tamagui tripping here
-              overflowY: 'scroll',
-            }}
           >
             <TokenBalanceList />
           </Card>
         </YStack>
-        {isSendingUnlocked && (
-          <XStack $lg={{ display: 'none' }} pt={'$4'} jc={'center'} gap={'$4'} w="100%">
-            <Stack f={1} w="50%" flexDirection="row-reverse" maw={350}>
-              <HomeButtons.GhostDepositButton />
-            </Stack>
-            <Stack f={1} w="50%" jc={'center'} maw={350}>
-              <HomeButtons.SendButton />
-            </Stack>
-          </XStack>
-        )}
       </YStack>
-
       {selectedCoin !== undefined && <TokenDetails coin={selectedCoin} />}
     </XStack>
   )


### PR DESCRIPTION
## Summary 

The PR introduces a new "Send" action to the HomeQuickActions component, 
which is conditionally displayed based on the user's sending unlock status and 
screen size. The TokenDetails component now also considers the sending unlock 
status when rendering the HomeQuickActions.


## Changes Made

- Added a new "Send" action to HomeQuickActions
- Introduced conditional rendering of HomeQuickActions in TokenDetails
- Updated HomeBody to animate HomeQuickActions and TokenBalanceList
- Removed redundant code in HomeBody
- Added useIsSendingUnlocked hook to TokenDetails

_written by Kolwaii, your beloved blockchain engineer AI agent_