### PR TITLE
Fixed hover styles type issue

### DIFF
--- a/packages/app/components/FormFields/CoinField.tsx
+++ b/packages/app/components/FormFields/CoinField.tsx
@@ -79,7 +79,6 @@ export const CoinField = ({
               focusStyle={{
                 bc: 'transparent',
               }}
-              // @ts-expect-error - background type is confused here
               hoverStyle={hoverStyles}
               $gtSm={{ p: '$2.5' }}
               iconAfter={

--- a/packages/app/components/SearchBar.tsx
+++ b/packages/app/components/SearchBar.tsx
@@ -387,7 +387,6 @@ function SearchResultRow({
       key={`SearchResultRow-${keyField}-${profile.tag_name}-${profile.send_id}`}
       width="100%"
       p={'$4'}
-      // @ts-expect-error - background type is confused here
       hoverStyle={hoverStyles}
     >
       <Link href={href}>

--- a/packages/app/components/sidebar/HomeSideBar.tsx
+++ b/packages/app/components/sidebar/HomeSideBar.tsx
@@ -178,13 +178,7 @@ const HomeBottomSheet = () => {
                 paddingTop={first ? '$2' : 0}
                 paddingBottom={last ? '$2' : 0}
               >
-                <YStack
-                  w={'100%'}
-                  p={'$4'}
-                  borderRadius={'$4'}
-                  // @ts-expect-error - background type is confused here
-                  hoverStyle={hoverStyles}
-                >
+                <YStack w={'100%'} p={'$4'} borderRadius={'$4'} hoverStyle={hoverStyles}>
                   <SideBarNavLink key={link.href} hoverStyle={{}} {...link} />
                 </YStack>
               </YStack>

--- a/packages/app/features/account/screen.tsx
+++ b/packages/app/features/account/screen.tsx
@@ -247,7 +247,6 @@ const StackButton = ({ href, label, icon }: { href: string; label: string; icon:
       backgroundColor={'$color1'}
       borderRadius={'$6'}
       p={'$5'}
-      // @ts-expect-error - background type is confused here
       hoverStyle={hoverStyles}
       $gtLg={{ p: '$7' }}
     >

--- a/packages/app/features/account/settings/SettingsNavLink.tsx
+++ b/packages/app/features/account/settings/SettingsNavLink.tsx
@@ -19,7 +19,6 @@ export function SettingsNavLink({
         p="$3.5"
         br={'$4'}
         $gtLg={{ p: '$5' }}
-        // @ts-expect-error - background type is confused here
         hoverStyle={hoverStyles}
       >
         <XStack gap="$3.5" ai="center">

--- a/packages/app/features/deposit/components/DepositOptionButton.tsx
+++ b/packages/app/features/deposit/components/DepositOptionButton.tsx
@@ -17,7 +17,6 @@ export function DepositOptionButton({ title, description, Icon, href }: DepositO
 
   return (
     <Link href={href}>
-      {/* @ts-expect-error - background type is confused here */}
       <FadeCard hoverStyle={hoverStyles}>
         <XStack ai={'center'} jc={'space-between'}>
           <XStack gap={'$5'} ai={'center'} f={1}>

--- a/packages/app/features/home/HomeQuickActions.tsx
+++ b/packages/app/features/home/HomeQuickActions.tsx
@@ -29,9 +29,7 @@ const QuickActionButton = ({ href, children }: LinkableButtonProps) => {
       href={href}
       f={1}
       height={'auto'}
-      // @ts-expect-error - background type is confused here
       hoverStyle={hoverStyles}
-      // @ts-expect-error - background type is confused here
       focusStyle={hoverStyles}
       w="100%"
     >

--- a/packages/app/features/home/TokenActivityRow.tsx
+++ b/packages/app/features/home/TokenActivityRow.tsx
@@ -45,7 +45,6 @@ export function TokenActivityRow({
       cursor={onPress ? 'pointer' : 'default'}
       $gtLg={{ p: '$5' }}
       testID={'TokenActivityRow'}
-      // @ts-expect-error - background type is confused here
       hoverStyle={onPress ? hoverStyles : null}
       onPress={() => onPress?.(activity)}
     >

--- a/packages/app/features/home/TokenBalanceList.tsx
+++ b/packages/app/features/home/TokenBalanceList.tsx
@@ -36,7 +36,6 @@ export const TokenBalanceList = () => {
           pathname: '/',
           query: { token: coin.token },
         }}
-        // @ts-expect-error - background type is confused here
         hoverStyle={hoverStyles}
         tokensMarketData={tokensMarketData}
         isLoadingTokensMarketData={isLoadingTokensMarketData}

--- a/packages/app/features/swap/form/screen.tsx
+++ b/packages/app/features/swap/form/screen.tsx
@@ -605,7 +605,6 @@ export const SwapFormScreen = () => {
                         circular={true}
                         size={'$5'}
                         borderWidth={0}
-                        // @ts-expect-error - background type is confused here
                         hoverStyle={hoverStyles}
                         onPress={handleFlipTokens}
                       >
@@ -735,7 +734,6 @@ export const Slippage = ({
               type={'button'}
               key={`slippage-${slippageOption}`}
               onPress={() => handleOnPress(slippageOption)}
-              // @ts-expect-error - background type is confused here
               hoverStyle={hoverStyles}
               bw={0}
               p={'$2'}

--- a/packages/app/utils/useHoverStyles.ts
+++ b/packages/app/utils/useHoverStyles.ts
@@ -1,16 +1,15 @@
-import type { GetThemeValueForKey } from '@my/ui'
 import { useThemeSetting } from '@tamagui/next-theme'
-import type { OpaqueColorValue } from 'react-native'
 
 export const useHoverStyles = (): {
-  background: GetThemeValueForKey<'backgroundColor'> | OpaqueColorValue
+  background: `rgba(${string})`
   transition: string
   cursor: string
 } => {
   const { resolvedTheme } = useThemeSetting()
 
-  const rowHoverBC: GetThemeValueForKey<'backgroundColor'> | OpaqueColorValue =
-    resolvedTheme?.startsWith('dark') ? 'rgba(255,255,255, 0.1)' : 'rgba(0,0,0, 0.1)'
+  const rowHoverBC = resolvedTheme?.startsWith('dark')
+    ? 'rgba(255,255,255, 0.1)'
+    : 'rgba(0,0,0, 0.1)'
 
   return {
     background: rowHoverBC,


### PR DESCRIPTION
## Summary 

Fixed hover styles type issue by removing ts-expect-error comments and updating background type in useHoverStyles.


## Changes Made

- Removed ts-expect-error comments for hover styles
- Updated background type in useHoverStyles to `rgba(${string})`

_written by Kolwaii, your beloved blockchain engineer AI agent_