### PR TITLE
fix: drop react-native-passkeys and used patched version

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -33,6 +33,7 @@
     "remove-xcode-env-local-file": "rm ios/.xcode.env.local"
   },
   "dependencies": {
+    "@0xbigboss/react-native-passkeys": "0.4.0",
     "@babel/runtime": "^7.18.9",
     "@my/ui": "workspace:*",
     "@react-native-async-storage/async-storage": "^2.0.0",
@@ -70,7 +71,6 @@
     "react-native": "0.76.9",
     "react-native-dotenv": "^3.4.9",
     "react-native-gesture-handler": "~2.20.2",
-    "react-native-passkeys": "^0.3.1",
     "react-native-reanimated": "~3.16.6",
     "react-native-safe-area-context": "5.0.0",
     "react-native-screens": "~4.4.0",

--- a/packages/app/utils/getRpId.ts
+++ b/packages/app/utils/getRpId.ts
@@ -3,9 +3,8 @@ import { Platform } from 'react-native'
 
 export function getRpId() {
   const bundleId = applicationId?.split('.').reverse().join('.')
-  const web = window ? window.location.hostname : undefined
   return Platform.select({
-    web,
+    web: undefined,
     ios: bundleId,
     android: bundleId?.replaceAll('_', '-'),
   })

--- a/packages/app/utils/getRpId.ts
+++ b/packages/app/utils/getRpId.ts
@@ -3,8 +3,9 @@ import { Platform } from 'react-native'
 
 export function getRpId() {
   const bundleId = applicationId?.split('.').reverse().join('.')
+  const web = window ? window.location.hostname : undefined
   return Platform.select({
-    web: undefined,
+    web,
     ios: bundleId,
     android: bundleId?.replaceAll('_', '-'),
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -20262,6 +20262,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "expo-app@workspace:apps/expo"
   dependencies:
+    "@0xbigboss/react-native-passkeys": "npm:0.4.0"
     "@babel/core": "npm:^7.24"
     "@babel/runtime": "npm:^7.18.9"
     "@expo/metro-config": "npm:~0.19.0"
@@ -20308,7 +20309,6 @@ __metadata:
     react-native-clean-project: "npm:^4.0.3"
     react-native-dotenv: "npm:^3.4.9"
     react-native-gesture-handler: "npm:~2.20.2"
-    react-native-passkeys: "npm:^0.3.1"
     react-native-reanimated: "npm:~3.16.6"
     react-native-safe-area-context: "npm:5.0.0"
     react-native-screens: "npm:~4.4.0"
@@ -30409,17 +30409,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/4cdf2b2fb5b131f2015c26d2cb7688b4a0c5f3c8474b1bf0ddfa9eabb0263df440c87262ae8f812a6ecab0d5310df0373bddad4b51f53dabb2ffee01e9ef0f44
-  languageName: node
-  linkType: hard
-
-"react-native-passkeys@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "react-native-passkeys@npm:0.3.1"
-  peerDependencies:
-    expo: "*"
-    react: "*"
-    react-native: "*"
-  checksum: 10/9361867994567b31abe92814c501cdf6410566efe97f6780f3e6e0a10bb251c593cea9d58939d4f2dd6bb7352ff31ac69e099c30b7829949a6ffc5c9bd071358
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- **fix(app): recalculate the rpId when requesting passkey**
- **fix(app): check if window is defined**
- **fix: drop react-native-passkeys and used patched version**
