### PR TITLE
Fix Disclaimer dialog for Megapot

### DIFF
--- a/packages/app/features/sendpot/hooks/useDidUserBuyTicket.tsx
+++ b/packages/app/features/sendpot/hooks/useDidUserBuyTicket.tsx
@@ -16,7 +16,8 @@ export const useDidUserBuyTicket = () => {
         return false
       }
       return (
-        pendingJackpotTickets.data > 0 || userJackpotSummary?.data?.find((s) => s.total_tickets > 0)
+        pendingJackpotTickets.data > 0 ||
+        userJackpotSummary.data.find((s) => s.total_tickets > 0) !== undefined
       )
     },
   })


### PR DESCRIPTION
If you didn't buy a ticket on the current round but did previously, it would still continue to show the risk dialog. 