### PR TITLE
Changed referral texts

### DIFF
--- a/apps/next/pages/account/affiliate.tsx
+++ b/apps/next/pages/account/affiliate.tsx
@@ -9,24 +9,20 @@ export const Page: NextPageWithLayout = () => {
   return (
     <>
       <Head>
-        <title>Send | Affiliates</title>
-        <meta
-          name="description"
-          content="View your network and track referral activity."
-          key="desc"
-        />
+        <title>Send | Friends</title>
+        <meta name="description" content="View invited friends and track activity." key="desc" />
       </Head>
       <AffiliateScreen />
     </>
   )
 }
 
-const subheader = 'View your network and track referral activity.'
+const subheader = 'View invited friends and track activity.'
 
 export const getServerSideProps = userProtectedGetSSP()
 
 Page.getLayout = (children) => (
-  <HomeLayout TopNav={<TopNav header="Affiliate" subheader={subheader} />}>{children}</HomeLayout>
+  <HomeLayout TopNav={<TopNav header="Friends" subheader={subheader} />}>{children}</HomeLayout>
 )
 
 export default Page

--- a/packages/app/features/account/components/AccountHeader.tsx
+++ b/packages/app/features/account/components/AccountHeader.tsx
@@ -66,7 +66,7 @@ export const AccountHeader = (props: YStackProps) => {
             <Button.Icon>
               <IconShare size={'$1.5'} color={'$primary'} $theme-light={{ color: '$color12' }} />
             </Button.Icon>
-            <Button.Text size={'$5'}>Refer Friends</Button.Text>
+            <Button.Text size={'$5'}>Invite Friends</Button.Text>
           </Button>
           <Button f={1} py={'$5'} h={'auto'} br={'$5'} bw={0} hoverStyle={hoverStyles}>
             <Button.Icon>

--- a/packages/app/features/account/components/AccountLinks.tsx
+++ b/packages/app/features/account/components/AccountLinks.tsx
@@ -58,7 +58,7 @@ const ACCOUNT_LINKS: {
       icon: <IconStarOutline {...iconProps} />,
     },
     {
-      text: 'Affiliate',
+      text: 'Friends',
       href: '/account/affiliate',
       icon: <IconDollar {...iconProps} scale={1.2} />,
     },

--- a/packages/app/features/affiliate/screen.tsx
+++ b/packages/app/features/affiliate/screen.tsx
@@ -50,7 +50,7 @@ const StatsCards = () => {
       >
         <Card $gtLg={{ flexShrink: 0, flexBasis: '32%' }} w="100%" mih={152}>
           <CardHeader>
-            <Label color={'$color10'}>Total Referrals</Label>
+            <Label color={'$color10'}>Your Friends</Label>
           </CardHeader>
           {isLoading ? (
             <Spinner alignSelf="flex-start" size="large" color="$color12" mt="auto" p="$4" />
@@ -94,7 +94,9 @@ const ReferralsList = () => {
   return (
     <YStack space="$4">
       <XStack alignItems="center" gap="$3">
-        <H3 fontWeight={'normal'}>{!pages || !pages[0]?.length ? 'No Referrals' : 'Referrals'}</H3>
+        <H3 fontWeight={'normal'}>
+          {!pages || !pages[0]?.length ? 'No invited friends yet' : 'Friends'}
+        </H3>
       </XStack>
       {Boolean(pages?.[0]?.length) && (
         <Card gap="$5" p="$5" w="100%" fd="row" flexWrap="wrap">
@@ -144,7 +146,9 @@ const ReferralsList = () => {
 
 const ReferralsListRow = ({
   referral,
-}: { referral: Functions<'get_affiliate_referrals'>[number] }) => {
+}: {
+  referral: Functions<'get_affiliate_referrals'>[number]
+}) => {
   const date = new Date(referral?.created_at).toLocaleString(undefined, { dateStyle: 'medium' })
 
   return (


### PR DESCRIPTION
## Summary 

The PR updates the referral system to use the term "Friends" instead of "Affiliates". 
It changes the title, meta description, and subheader of the affiliate page, 
and updates the text of buttons and links to reflect the new terminology.


## Changes Made

- Update title and meta description of affiliate page
- Change subheader to "View invited friends and track activity"
- Update button text to "Invite Friends"
- Update link text to "Friends"

_written by Kolwaii, your beloved blockchain engineer AI agent_