### PR TITLE
Fix activity spinner position

### DIFF
--- a/packages/app/features/profile/screen.tsx
+++ b/packages/app/features/profile/screen.tsx
@@ -190,7 +190,7 @@ const TransactionEntry = ({
     data: { note },
   } = activity
   const amount = amountFromActivity(activity)
-  const date = useTransactionEntryDate({ activity })
+  const date = useTransactionEntryDate({ activity, sent })
 
   return (
     <XStack justifyContent={sent ? 'flex-end' : 'flex-start'} testID="activityTest" my={'$2.5'}>
@@ -272,7 +272,7 @@ const DatePill = ({ date }: { date: string }) => {
   )
 }
 
-const useTransactionEntryDate = ({ activity }: { activity: Activity }) => {
+const useTransactionEntryDate = ({ activity, sent }: { activity: Activity; sent: boolean }) => {
   const { created_at, data } = activity
   const isTemporalTransfer =
     isTemporalEthTransfersEvent(activity) || isTemporalTokenTransfersEvent(activity)
@@ -285,7 +285,9 @@ const useTransactionEntryDate = ({ activity }: { activity: Activity }) => {
       case 'confirmed':
         return new Date(created_at).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
       default:
-        return <Spinner size="small" color={'$color11'} alignItems={'flex-start'} />
+        return (
+          <Spinner size="small" color={'$color11'} alignItems={sent ? 'flex-end' : 'flex-start'} />
+        )
     }
   }
 


### PR DESCRIPTION
## Summary 

The PR updates the activity spinner position and the useTransactionEntryDate hook to consider the 'sent' status.


## Changes Made

- Update activity spinner position based on 'sent' status
- Modify useTransactionEntryDate hook to accept 'sent' parameter
- Align spinner with 'flex-end' when 'sent' is true

_written by Kolwaii, your beloved blockchain engineer AI agent_