### PR TITLE
Added send id to account page when no send tags

### DIFF
--- a/packages/app/components/ReferralLink.tsx
+++ b/packages/app/components/ReferralLink.tsx
@@ -13,10 +13,13 @@ import { CheckCheck } from '@tamagui/lucide-icons'
 import { useEffect, useState } from 'react'
 import { IconCopy } from './icons'
 import * as Clipboard from 'expo-clipboard'
+import { useConfirmedTags } from 'app/utils/tags'
 
 export function ReferralLink(props: ButtonProps) {
-  const { profile, tags } = useUser()
-  const referralCode = tags?.[0]?.name || profile?.referral_code
+  const { profile } = useUser()
+  const send_id = profile?.send_id
+  const tags = useConfirmedTags()
+  const referralCode = tags?.[0]?.name
   const referralHref = `https://send.app?referral=${referralCode}`
   const toast = useToastController()
   const [hasCopied, setHasCopied] = useState(false)
@@ -42,7 +45,18 @@ export function ReferralLink(props: ButtonProps) {
     }
   }, [hasCopied])
 
-  if (!referralCode) return null
+  if (!referralCode) {
+    return (
+      <XStack ai={'center'} gap={'$2'} width={'100%'}>
+        <Paragraph size={'$5'} color={'$color10'}>
+          Send ID:
+        </Paragraph>
+        <Paragraph fontSize={'$5'} fontWeight={'500'}>
+          {send_id}
+        </Paragraph>
+      </XStack>
+    )
+  }
 
   return (
     <XStack ai={'center'} gap={'$2'} width={'100%'}>

--- a/packages/app/features/account/components/AccountHeader.tsx
+++ b/packages/app/features/account/components/AccountHeader.tsx
@@ -6,9 +6,11 @@ import { ReferralLink } from 'app/components/ReferralLink'
 import { useEffect, useState } from 'react'
 import * as Sharing from 'expo-sharing'
 import { useHoverStyles } from 'app/utils/useHoverStyles'
+import { useConfirmedTags } from 'app/utils/tags'
 
 export const AccountHeader = (props: YStackProps) => {
-  const { profile, tags } = useUser()
+  const { profile } = useUser()
+  const tags = useConfirmedTags()
   const avatar_url = profile?.avatar_url
   const name = profile?.name
   const referralCode = tags?.[0]?.name || profile?.referral_code


### PR DESCRIPTION
## Summary 

The PR updates the ReferralLink component to display the send ID when no send tags are available. It also modifies the AccountHeader component to use the confirmed tags.


## Changes Made

- Added send ID display to ReferralLink component
- Updated AccountHeader component to use confirmed tags
- Modified referral code logic in ReferralLink component

_written by Kolwaii, your beloved blockchain engineer AI agent_