### PR TITLE
Hide account and activity buttons in nav on activity page

### DIFF
--- a/apps/next/pages/account/index.tsx
+++ b/apps/next/pages/account/index.tsx
@@ -22,7 +22,10 @@ export const Page: NextPageWithLayout = () => {
 
 export const getServerSideProps = userProtectedGetSSP()
 Page.getLayout = () => (
-  <HomeLayout TopNav={<TopNav header="Account" showOnGtLg={true} />} fullHeight>
+  <HomeLayout
+    TopNav={<TopNav header="Account" showOnGtLg={true} hideRightActions={true} />}
+    fullHeight
+  >
     <AccountScreenLayout />
   </HomeLayout>
 )

--- a/packages/app/components/TopNav.tsx
+++ b/packages/app/components/TopNav.tsx
@@ -43,6 +43,7 @@ interface TopNavProps {
    * @default false
    */
   showOnGtLg?: boolean
+  hideRightActions?: boolean
 }
 
 export function AvatarMenuButton({ profile }: { profile?: Tables<'profiles'> | null }) {
@@ -98,6 +99,7 @@ export function TopNav({
   noSubroute = false,
   backFunction = 'root',
   showOnGtLg = false,
+  hideRightActions = false,
 }: TopNavProps) {
   const [queryParams, setRootParams] = useRootScreenParams()
   const path = usePathname()
@@ -201,6 +203,8 @@ export function TopNav({
                   <XStack
                     jc="center"
                     gap="$2"
+                    opacity={hideRightActions ? 0 : 1}
+                    pointerEvents={hideRightActions ? 'none' : 'unset'}
                     $gtLg={{
                       pointerEvents: 'none',
                       opacity: 0,


### PR DESCRIPTION
## Summary 

The PR introduces a new feature to hide account and activity buttons in the navigation bar on the account page.


## Changes Made

- Hide account and activity buttons in nav on account page
- Add hideRightActions prop to TopNav component
- Update HomeLayout to use new TopNav prop

_written by Kolwaii, your beloved blockchain engineer AI agent_