### PR TITLE
fix: add expo-constants mock for tests to support dynamic RPC URLs

### DIFF
--- a/packages/app/jest.setup-after-env.ts
+++ b/packages/app/jest.setup-after-env.ts
@@ -9,3 +9,19 @@ jest.mock('app/utils/send-accounts')
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
 jest.mock('app/utils/supabase/client')
 jest.mock('app/utils/useAddressBook')
+
+// Mock expo-constants to provide a fixed hostUri for tests
+// This is needed for:
+// 1. getRpcUrl.native.ts which uses Constants.expoConfig?.hostUri for localhost IP resolution
+// 2. CustomToast.tsx which uses Constants.executionEnvironment
+jest.mock('expo-constants', () => ({
+  expoConfig: {
+    hostUri: 'localhost:8081',
+  },
+  executionEnvironment: 'storeClient',
+  ExecutionEnvironment: {
+    StoreClient: 'storeClient',
+    Standalone: 'standalone',
+    Browser: 'browser',
+  },
+}))

--- a/yarn.lock
+++ b/yarn.lock
@@ -6283,6 +6283,7 @@ __metadata:
     "@wagmi/core": "npm:^2.16.7"
     change-case: "npm:^5.4.2"
     debug: "npm:^4.3.6"
+    expo-constants: "npm:~17.0.3"
     globby: "npm:^14.0.0"
     permissionless: "npm:^0.1.14"
     typescript: "npm:^5.8.3"


### PR DESCRIPTION
Added mock for expo-constants to provide a fixed hostUri for tests, which fixes test failures after the dynamic RPC URL implementation. Also fixed the CustomToast component test by mocking the ExecutionEnvironment property.

🤖 Generated with [Claude Code](https://claude.ai/code)