### PR TITLE
Today birthday senders

### DIFF
--- a/packages/app/features/send/screen.tsx
+++ b/packages/app/features/send/screen.tsx
@@ -26,9 +26,10 @@ import { type Address, isAddress } from 'viem'
 import { useRouter } from 'solito/router'
 import { IconAccount } from 'app/components/icons'
 import { shorten } from 'app/utils/strings'
-import { useRecentSenders } from 'app/features/activity/utils/useRecentSenders'
-import { SendSuggestions } from 'app/features/send/SendSuggestions'
-import { useFavouriteSenders } from 'app/features/activity/utils/useFavouriteSenders'
+import { useRecentSenders } from 'app/features/send/suggestions/useRecentSenders'
+import { SendSuggestions } from 'app/features/send/suggestions/SendSuggestions'
+import { useFavouriteSenders } from 'app/features/send/suggestions/useFavouriteSenders'
+import { useTodayBirthdaySenders } from 'app/features/send/suggestions/useTodayBirthdaySenders'
 
 export const SendScreen = () => {
   const [{ recipient, idType }] = useSendScreenParams()
@@ -39,9 +40,14 @@ export const SendScreen = () => {
   } = useProfileLookup(idType ?? 'tag', recipient ?? '')
   const recentSendersQuery = useRecentSenders()
   const favouriteSendersQuery = useFavouriteSenders()
+  const todayBirthdaySendersQuery = useTodayBirthdaySenders()
   const [{ search }] = useRootScreenParams()
+
   const isLoading =
-    isLoadingProfileLookup || recentSendersQuery.isLoading || favouriteSendersQuery.isLoading
+    isLoadingProfileLookup ||
+    recentSendersQuery.isLoading ||
+    favouriteSendersQuery.isLoading ||
+    todayBirthdaySendersQuery.isLoading
 
   if (isLoading) return <Spinner size="large" color={'$color12'} />
 
@@ -62,6 +68,7 @@ export const SendScreen = () => {
             <SendSuggestions
               recentSendersQuery={recentSendersQuery}
               favouriteSendersQuery={favouriteSendersQuery}
+              todayBirthdaySendersQuery={todayBirthdaySendersQuery}
             />
           )}
           <SendSearchBody />

--- a/packages/app/features/send/suggestions/SendSuggestion.types.ts
+++ b/packages/app/features/send/suggestions/SendSuggestion.types.ts
@@ -1,0 +1,6 @@
+import type { z } from 'zod'
+import type { UserSchema } from 'app/utils/zod/activity/UserSchema'
+import type { UseQueryResult } from '@tanstack/react-query'
+
+export type SendSuggestionItem = z.infer<typeof UserSchema>
+export type SendSuggestionsQueryResult = UseQueryResult<SendSuggestionItem[]>

--- a/packages/app/features/send/suggestions/SendSuggestions.tsx
+++ b/packages/app/features/send/suggestions/SendSuggestions.tsx
@@ -1,77 +1,56 @@
-import type {
-  UseRecentSendersItem,
-  UseRecentSendersResult,
-} from 'app/features/activity/utils/useRecentSenders'
 import { Avatar, Paragraph, YStack } from '@my/ui'
 import { FlatList } from 'react-native'
-import type { UseFavouriteSendersResult } from 'app/features/activity/utils/useFavouriteSenders'
 import { useSendScreenParams } from 'app/routers/params'
 import { Link } from 'solito/link'
+import type {
+  SendSuggestionItem,
+  SendSuggestionsQueryResult,
+} from 'app/features/send/suggestions/SendSuggestion.types'
 
 export const SendSuggestions = ({
   recentSendersQuery,
   favouriteSendersQuery,
+  todayBirthdaySendersQuery,
 }: {
-  recentSendersQuery: UseRecentSendersResult
-  favouriteSendersQuery: UseFavouriteSendersResult
+  recentSendersQuery: SendSuggestionsQueryResult
+  favouriteSendersQuery: SendSuggestionsQueryResult
+  todayBirthdaySendersQuery: SendSuggestionsQueryResult
 }) => {
   return (
     <>
-      <RecentSenders recentSendersQuery={recentSendersQuery} />
-      <FavouriteSenders favouriteSendersQuery={favouriteSendersQuery} />
+      <SuggestionsList
+        query={recentSendersQuery}
+        title={'Recent Activity'}
+        fallback={'Recent activity is empty, send it.'}
+      />
+      <SuggestionsList
+        query={favouriteSendersQuery}
+        title={'Favourite Senders'}
+        fallback={'No favourite senders, send it.'}
+      />
+      <SuggestionsList
+        query={todayBirthdaySendersQuery}
+        title={'Wish Them Happy Birthday'}
+        fallback={'No birthdays today, invite your friends to celebrate with them.'}
+      />
     </>
   )
 }
 
-const RecentSenders = ({ recentSendersQuery }: { recentSendersQuery: UseRecentSendersResult }) => {
-  const { error, data } = recentSendersQuery
-
-  return (
-    <YStack gap={'$3.5'}>
-      <Paragraph size="$7">Recent Activity</Paragraph>
-      {(() => {
-        switch (true) {
-          case !!error:
-            return (
-              <Paragraph color={'$error'}>
-                {error.message?.split('.')[0] ?? 'Unknown error'}
-              </Paragraph>
-            )
-          case !data || data.length === 0:
-            return (
-              <Paragraph
-                color={'$lightGrayTextField'}
-                $theme-light={{ color: '$darkGrayTextField' }}
-              >
-                Recent activity is empty, send it.
-              </Paragraph>
-            )
-          default:
-            return (
-              <FlatList
-                horizontal
-                data={data || []}
-                renderItem={({ item, index }) => <SenderSuggestion item={item} index={index} />}
-                keyExtractor={(item, index) => item?.send_id?.toString() ?? String(index)}
-                showsHorizontalScrollIndicator={false}
-              />
-            )
-        }
-      })()}
-    </YStack>
-  )
-}
-
-const FavouriteSenders = ({
-  favouriteSendersQuery,
+const SuggestionsList = ({
+  query,
+  fallback,
+  title,
 }: {
-  favouriteSendersQuery: UseFavouriteSendersResult
+  query: SendSuggestionsQueryResult
+  title: string
+  fallback: string
 }) => {
-  const { error, data } = favouriteSendersQuery
+  const { error, data } = query
 
   return (
     <YStack gap={'$3.5'}>
-      <Paragraph size="$7">Favourite Senders</Paragraph>
+      <Paragraph size="$7">{title}</Paragraph>
       {(() => {
         switch (true) {
           case !!error:
@@ -86,7 +65,7 @@ const FavouriteSenders = ({
                 color={'$lightGrayTextField'}
                 $theme-light={{ color: '$darkGrayTextField' }}
               >
-                No favourite senders, send it.
+                {fallback}
               </Paragraph>
             )
           default:
@@ -105,7 +84,7 @@ const FavouriteSenders = ({
   )
 }
 
-const SenderSuggestion = ({ item, index }: { item: UseRecentSendersItem; index: number }) => {
+const SenderSuggestion = ({ item, index }: { item: SendSuggestionItem; index: number }) => {
   const [sendParams] = useSendScreenParams()
   const _sendParams = JSON.parse(JSON.stringify(sendParams)) //JSON makes sure we don't pass undefined values
 

--- a/packages/app/features/send/suggestions/useFavouriteSenders.ts
+++ b/packages/app/features/send/suggestions/useFavouriteSenders.ts
@@ -1,13 +1,12 @@
-import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useSupabase } from 'app/utils/supabase/useSupabase'
 import { UserSchema } from 'app/utils/zod/activity/UserSchema'
 import { z } from 'zod'
+import type { SendSuggestionsQueryResult } from 'app/features/send/suggestions/SendSuggestion.types'
 
-export type UseFavouriteSendersItem = z.infer<typeof UserSchema>
-export type UseFavouriteSendersResult = UseQueryResult<UseFavouriteSendersItem[]>
 const QUERY_KEY = 'favourite_senders'
 
-export const useFavouriteSenders = (): UseFavouriteSendersResult => {
+export const useFavouriteSenders = (): SendSuggestionsQueryResult => {
   const supabase = useSupabase()
 
   return useQuery({

--- a/packages/app/features/send/suggestions/useRecentSenders.ts
+++ b/packages/app/features/send/suggestions/useRecentSenders.ts
@@ -1,13 +1,12 @@
-import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useSupabase } from 'app/utils/supabase/useSupabase'
 import { UserSchema } from 'app/utils/zod/activity/UserSchema'
 import { z } from 'zod'
+import type { SendSuggestionsQueryResult } from 'app/features/send/suggestions/SendSuggestion.types'
 
-export type UseRecentSendersItem = z.infer<typeof UserSchema>
-export type UseRecentSendersResult = UseQueryResult<UseRecentSendersItem[]>
 const QUERY_KEY = 'recent_senders'
 
-export const useRecentSenders = (): UseRecentSendersResult => {
+export const useRecentSenders = (): SendSuggestionsQueryResult => {
   const supabase = useSupabase()
 
   return useQuery({

--- a/packages/app/features/send/suggestions/useTodayBirthdaySenders.ts
+++ b/packages/app/features/send/suggestions/useTodayBirthdaySenders.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query'
+import { useSupabase } from 'app/utils/supabase/useSupabase'
+import { UserSchema } from 'app/utils/zod/activity/UserSchema'
+import { z } from 'zod'
+import type { SendSuggestionsQueryResult } from 'app/features/send/suggestions/SendSuggestion.types'
+
+const QUERY_KEY = 'today_birthday_senders'
+
+export const useTodayBirthdaySenders = (): SendSuggestionsQueryResult => {
+  const supabase = useSupabase()
+
+  return useQuery({
+    queryKey: [QUERY_KEY],
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc('today_birthday_senders')
+
+      if (error || !data) {
+        throw new Error(error?.message || 'Unable to fetch today birthday senders')
+      }
+
+      return z.array(UserSchema).parse(data)
+    },
+    retry: false,
+  })
+}
+
+useTodayBirthdaySenders.queryKey = QUERY_KEY

--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -1989,6 +1989,10 @@ export type Database = {
           user_id: string
         }[]
       }
+      today_birthday_senders: {
+        Args: Record<PropertyKey, never>
+        Returns: Database["public"]["CompositeTypes"]["activity_feed_user"][]
+      }
       update_distribution_shares: {
         Args: {
           distribution_id: number

--- a/supabase/migrations/20250523225150_today_birthday_senders.sql
+++ b/supabase/migrations/20250523225150_today_birthday_senders.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION today_birthday_senders()
+RETURNS SETOF activity_feed_user
+SECURITY DEFINER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+RETURN QUERY
+SELECT (
+   (
+    NULL,
+    p.name,
+    p.avatar_url,
+    p.send_id,
+    (
+        SELECT ARRAY_AGG(name)
+        FROM tags
+        WHERE user_id = p.id
+          AND status = 'confirmed'
+    )
+       )::activity_feed_user
+).*
+FROM profiles p
+WHERE is_public = TRUE
+  AND p.birthday IS NOT NULL
+  AND p.avatar_url IS NOT NULL
+  AND EXTRACT(MONTH FROM p.birthday) = EXTRACT(MONTH FROM CURRENT_DATE)
+  AND EXTRACT(DAY FROM p.birthday) = EXTRACT(DAY FROM CURRENT_DATE);
+END;
+$$;


### PR DESCRIPTION
## Summary 

The PR introduces a new feature to display today's birthday senders in the send screen. It includes a new query to fetch users with birthdays today and a new component to display the suggestions.


## Changes Made

- Added today birthday senders query
- Introduced new SendSuggestions component
- Updated useFavouriteSenders and useRecentSenders to return SendSuggestionsQueryResult
- Created new useTodayBirthdaySenders hook
- Modified SendScreen to include today birthday senders

_written by Kolwaii, your beloved blockchain engineer AI agent_