### PR TITLE
fix: implement Share Profile button functionality

### DIFF
--- a/packages/app/features/account/components/AccountHeader.tsx
+++ b/packages/app/features/account/components/AccountHeader.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import * as Sharing from 'expo-sharing'
 import { useHoverStyles } from 'app/utils/useHoverStyles'
 import { useConfirmedTags } from 'app/utils/tags'
+import { ShareProfileDialog } from './ShareProfileDialog'
 
 export const AccountHeader = (props: YStackProps) => {
   const { profile } = useUser()
@@ -16,6 +17,7 @@ export const AccountHeader = (props: YStackProps) => {
   const referralCode = tags?.[0]?.name || profile?.referral_code
   const referralHref = `https://send.app?referral=${referralCode}`
   const [canShare, setCanShare] = useState(false)
+  const [shareDialogOpen, setShareDialogOpen] = useState(false)
   const hoverStyles = useHoverStyles()
 
   useEffect(() => {
@@ -70,7 +72,15 @@ export const AccountHeader = (props: YStackProps) => {
             </Button.Icon>
             <Button.Text size={'$5'}>Invite Friends</Button.Text>
           </Button>
-          <Button f={1} py={'$5'} h={'auto'} br={'$5'} bw={0} hoverStyle={hoverStyles}>
+          <Button
+            f={1}
+            py={'$5'}
+            h={'auto'}
+            br={'$5'}
+            bw={0}
+            hoverStyle={hoverStyles}
+            onPress={() => setShareDialogOpen(true)}
+          >
             <Button.Icon>
               <IconQRFull size={'$1'} color={'$primary'} $theme-light={{ color: '$color12' }} />
             </Button.Icon>
@@ -78,6 +88,7 @@ export const AccountHeader = (props: YStackProps) => {
           </Button>
         </XStack>
       </Fade>
+      <ShareProfileDialog isOpen={shareDialogOpen} onClose={() => setShareDialogOpen(false)} />
     </YStack>
   )
 }

--- a/packages/app/features/account/components/ShareProfileDialog.tsx
+++ b/packages/app/features/account/components/ShareProfileDialog.tsx
@@ -1,0 +1,120 @@
+import { Button, Dialog, Image, Paragraph, Separator, XStack, YStack } from '@my/ui'
+import { useUser } from 'app/utils/useUser'
+import { useConfirmedTags } from 'app/utils/tags'
+import { useEffect, useState } from 'react'
+import QRCode from 'qrcode'
+import * as Clipboard from 'expo-clipboard'
+import { useToastController } from '@my/ui'
+import { IconCopy } from 'app/components/icons'
+
+interface ShareProfileDialogProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function ShareProfileDialog({ isOpen, onClose }: ShareProfileDialogProps) {
+  const { profile } = useUser()
+  const tags = useConfirmedTags()
+  const toast = useToastController()
+  const [qrCodeDataURL, setQrCodeDataURL] = useState<string>('')
+
+  // Use sendtag if available, otherwise fall back to send_id
+  const sendtag = tags?.[0]?.name
+  const profileUrl = sendtag
+    ? `https://send.app/${sendtag}`
+    : `https://send.app/${profile?.send_id}`
+
+  useEffect(() => {
+    if (isOpen && profileUrl) {
+      QRCode.toDataURL(profileUrl, {
+        width: 200,
+        margin: 2,
+        color: {
+          dark: '#000000',
+          light: '#FFFFFF',
+        },
+      })
+        .then(setQrCodeDataURL)
+        .catch(() => setQrCodeDataURL(''))
+    }
+  }, [isOpen, profileUrl])
+
+  const handleCopyLink = async () => {
+    try {
+      await Clipboard.setStringAsync(profileUrl)
+      toast.show('Profile link copied to clipboard')
+    } catch {
+      toast.show('Failed to copy link', {
+        message: 'Something went wrong while copying the link',
+        customData: {
+          theme: 'red',
+        },
+      })
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <Dialog.Portal>
+        <Dialog.Overlay />
+        <Dialog.Content
+          width={'85%'}
+          br={'$5'}
+          p={'$5'}
+          gap={'$3.5'}
+          maxWidth={400}
+          $gtLg={{ p: '$7', gap: '$5' }}
+        >
+          <Paragraph size={'$8'} fontWeight={500}>
+            Share Profile
+          </Paragraph>
+          <Separator boc={'$silverChalice'} $theme-light={{ boc: '$darkGrayTextField' }} />
+
+          {qrCodeDataURL && (
+            <YStack ai={'center'} gap={'$3'}>
+              <Image source={{ uri: qrCodeDataURL }} width={200} height={200} br={'$3'} />
+              <Paragraph size={'$4'} color={'$color10'} ta={'center'} numberOfLines={1}>
+                {profileUrl}
+              </Paragraph>
+            </YStack>
+          )}
+          <YStack
+            justifyContent="space-between"
+            marginTop="$4"
+            gap="$4"
+            $gtLg={{ flexDirection: 'row-reverse' }}
+          >
+            <Button
+              theme="green"
+              borderRadius={'$4'}
+              p={'$4'}
+              onPress={handleCopyLink}
+              focusStyle={{ outlineWidth: 0 }}
+            >
+              <Button.Icon>
+                <IconCopy size={16} color={'$black'} />
+              </Button.Icon>
+              <Button.Text
+                ff={'$mono'}
+                fontWeight={'500'}
+                tt="uppercase"
+                size={'$5'}
+                color={'$black'}
+                ml={'$2'}
+              >
+                copy link
+              </Button.Text>
+            </Button>
+            <Dialog.Close asChild>
+              <Button borderRadius={'$4'} p={'$4'} focusStyle={{ outlineWidth: 0 }}>
+                <Button.Text ff={'$mono'} fontWeight={'500'} tt="uppercase" size={'$5'}>
+                  close
+                </Button.Text>
+              </Button>
+            </Dialog.Close>
+          </YStack>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
+  )
+}

--- a/packages/app/features/account/components/ShareProfileDialog.tsx
+++ b/packages/app/features/account/components/ShareProfileDialog.tsx
@@ -23,7 +23,7 @@ export function ShareProfileDialog({ isOpen, onClose }: ShareProfileDialogProps)
   const hostname = isWeb ? window.location.hostname : 'send.app'
   const profileUrl = sendtag
     ? `https://${hostname}/${sendtag}`
-    : `https://${hostname}/${profile?.send_id}`
+    : `https://${hostname}/profile/${profile?.send_id}`
 
   useEffect(() => {
     if (isOpen && profileUrl) {

--- a/packages/app/features/account/components/ShareProfileDialog.tsx
+++ b/packages/app/features/account/components/ShareProfileDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Dialog, Image, Paragraph, Separator, XStack, YStack } from '@my/ui'
+import { Button, Dialog, Image, isWeb, Paragraph, Separator, XStack, YStack } from '@my/ui'
 import { useUser } from 'app/utils/useUser'
 import { useConfirmedTags } from 'app/utils/tags'
 import { useEffect, useState } from 'react'
@@ -20,9 +20,10 @@ export function ShareProfileDialog({ isOpen, onClose }: ShareProfileDialogProps)
 
   // Use sendtag if available, otherwise fall back to send_id
   const sendtag = tags?.[0]?.name
+  const hostname = isWeb ? window.location.hostname : 'send.app'
   const profileUrl = sendtag
-    ? `https://send.app/${sendtag}`
-    : `https://send.app/${profile?.send_id}`
+    ? `https://${hostname}/${sendtag}`
+    : `https://${hostname}/${profile?.send_id}`
 
   useEffect(() => {
     if (isOpen && profileUrl) {


### PR DESCRIPTION
Add ShareProfileDialog component with QR code generation and copy-to-clipboard functionality. The dialog shows a QR code linking to the user's profile URL (using sendtag if available, otherwise send_id) and provides a button to copy the profile link.

- Create ShareProfileDialog component with QR code and copy functionality
- Update AccountHeader to include dialog state and onPress handler
- Use existing qrcode library and expo-clipboard for functionality
- Follow existing dialog patterns and styling conventions

Fixes #1512

Generated with [Claude Code](https://claude.ai/code)