### PR TITLE
fix: fix normalizeRedirectUrl to preserve query parameters

### DIFF
--- a/apps/next/utils/normalizeRedirectUrl.test.ts
+++ b/apps/next/utils/normalizeRedirectUrl.test.ts
@@ -29,7 +29,34 @@ describe('normalizeRedirectUrl', () => {
   })
 
   it('should handle index routes correctly', () => {
-    expect(normalizeRedirectUrl('/_next/data/abc123/index.json')).toBe('/index')
-    // Note: You might want to handle index -> / conversion if needed
+    expect(normalizeRedirectUrl('/_next/data/abc123/index.json')).toBe('/')
+  })
+
+  it('should preserve query parameters', () => {
+    expect(normalizeRedirectUrl('/_next/data/abc123/send.json?recipient=alice')).toBe(
+      '/send?recipient=alice'
+    )
+    expect(normalizeRedirectUrl('/_next/data/build-id/profile/bigboss.json?tab=activity')).toBe(
+      '/profile/bigboss?tab=activity'
+    )
+    expect(normalizeRedirectUrl('/send.json?idType=tag&recipient=alice')).toBe(
+      '/send?idType=tag&recipient=alice'
+    )
+  })
+
+  it('should handle complex query parameters with encoding', () => {
+    expect(
+      normalizeRedirectUrl(
+        '/_next/data/development/index.json?redirectUri=%2Fsend%3Frecipient%3Dalice'
+      )
+    ).toBe('/?redirectUri=%2Fsend%3Frecipient%3Dalice')
+  })
+
+  it('should handle the problematic URL from the logs', () => {
+    const problematicUrl =
+      '/_next/data/development/index.json?redirectUri=%2F_next%2Fdata%2Fdevelopment%2Fsend.json%3FidType%3Dtag%26recipient%3Dalice'
+    const expected =
+      '/?redirectUri=%2F_next%2Fdata%2Fdevelopment%2Fsend.json%3FidType%3Dtag%26recipient%3Dalice'
+    expect(normalizeRedirectUrl(problematicUrl)).toBe(expected)
   })
 })

--- a/apps/next/utils/normalizeRedirectUrl.ts
+++ b/apps/next/utils/normalizeRedirectUrl.ts
@@ -1,22 +1,33 @@
 /**
  * Normalizes URLs for authentication redirects
  * Converts Next.js data URLs (/_next/data/[buildId]/path.json) to regular paths (/path)
+ * Preserves query parameters while normalizing the path
  */
 export function normalizeRedirectUrl(url: string | undefined): string | undefined {
   if (!url) return url
 
+  // Parse URL to separate path and query parameters
+  const urlObj = new URL(url, 'http://localhost') // base URL needed for relative URLs
+  const pathname = urlObj.pathname
+  const search = urlObj.search
+
+  let normalizedPath = pathname
+
   // Handle Next.js data URLs: /_next/data/[buildId]/path.json -> /path
-  if (url.startsWith('/_next/data/')) {
+  if (pathname.startsWith('/_next/data/')) {
     // Extract the path from the data URL
     // Pattern: /_next/data/[buildId]/...path.json
-    const match = url.match(/^\/_next\/data\/[^/]+\/(.*)\.json$/)
+    const match = pathname.match(/^\/_next\/data\/[^/]+\/(.*)\.json$/)
     if (match) {
-      return `/${match[1]}`
+      const path = match[1]
+      // Convert index to root path
+      normalizedPath = path === 'index' ? '/' : `/${path}`
     }
-  } else if (url.endsWith('.json')) {
+  } else if (pathname.endsWith('.json')) {
     // Handle regular .json URLs
-    return url.replace(/\.json$/, '')
+    normalizedPath = pathname.replace(/\.json$/, '')
   }
 
-  return url
+  // Combine normalized path with query parameters
+  return normalizedPath + search
 }

--- a/apps/next/utils/userProtected.ts
+++ b/apps/next/utils/userProtected.ts
@@ -30,8 +30,6 @@ export function userProtectedGetSSP<
       } = await supabase.auth.getSession()
 
       if (!session || error) {
-        log('no session')
-
         const normalizedUrl = normalizeRedirectUrl(ctx.req.url)
 
         const destination =
@@ -39,6 +37,7 @@ export function userProtectedGetSSP<
             ? '/'
             : `/?redirectUri=${encodeURIComponent(normalizedUrl)}`
 
+        log(`no session redirectUri=${normalizedUrl}`)
         return {
           redirect: {
             destination,


### PR DESCRIPTION
## Summary 

The PR enhances the `normalizeRedirectUrl` function to preserve query parameters and handle complex URLs during normalization.


## Changes Made

- Enhance `normalizeRedirectUrl` to preserve query parameters
- Handle complex URLs during normalization
- Update tests for `normalizeRedirectUrl`
- Fix redirect URL handling in `userProtectedGetSSP`

_written by Kolwaii, your beloved blockchain engineer AI agent_