### PR TITLE
Changed toSorted to spread and sort

### DIFF
--- a/packages/app/features/home/InvestmentsBalanceCard.tsx
+++ b/packages/app/features/home/InvestmentsBalanceCard.tsx
@@ -110,9 +110,10 @@ function InvestmentsPreview() {
       .map((coin) => ({ ...coin, balance: 0n })),
   ]
 
-  const sortedByBalance = coins.toSorted((a, b) =>
+  const sortedByBalance = [...coins].sort((a, b) =>
     (b?.balance ?? 0n) > (a?.balance ?? 0n) ? 1 : -1
   )
+
   return (
     <XStack ai="center">
       <OverlappingCoinIcons coins={sortedByBalance} />


### PR DESCRIPTION
## Replace `toSorted()` with spread + `sort()` for iOS compatibility

### Problem
`toSorted()` is not supported in Hermes JavaScript engine on iOS, causing runtime errors despite being available in modern browsers and Node.js.

### Solution
Replace `array.toSorted()` with `[...array].sort()` which provides identical functionality:
- Creates a new sorted array without mutating the original
- Works across all JavaScript environments
- More explicit about creating a new array

### Changes
- ✅ Replaced `toSorted()` calls with spread operator + `sort()`
- ✅ Maintains same sorting behavior and immutability
- ✅ No breaking changes to component logic

### Testing
- [x] Verified sorting works correctly on iOS
- [x] Confirmed original arrays remain unchanged
- [x] No runtime errors in development/production

### Example
```diff
- const sortedData = items.toSorted((a, b) => a.value - b.value);
+ const sortedData = [...items].sort((a, b) => a.value - b.value);
```

**Impact**: Fixes iOS compatibility issue while maintaining identical functionality.