### PR TITLE
Native: refactor stack imports

### DIFF
--- a/apps/expo/app/(tabs)/activity/index.tsx
+++ b/apps/expo/app/(tabs)/activity/index.tsx
@@ -1,11 +1,11 @@
 import { Paragraph } from '@my/ui'
 import { TabScreenContainer } from 'apps-expo/components/layout/TabScreenContainer'
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 
 export default function ActivityTabScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Activity',
         }}

--- a/apps/expo/app/(tabs)/explore/index.tsx
+++ b/apps/expo/app/(tabs)/explore/index.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 import { TabScreenContainer } from 'apps-expo/components/layout/TabScreenContainer'
 
 export default function ExploreScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Explore',
         }}

--- a/apps/expo/app/+not-found.tsx
+++ b/apps/expo/app/+not-found.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function NotFoundScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Not Found',
         }}

--- a/apps/expo/app/[tag].tsx
+++ b/apps/expo/app/[tag].tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function TagScreenScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'History',
         }}

--- a/apps/expo/app/account/affiliate.tsx
+++ b/apps/expo/app/account/affiliate.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function ReferralsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Referrals',
         }}

--- a/apps/expo/app/account/backup/confirm/[cread_id].tsx
+++ b/apps/expo/app/account/backup/confirm/[cread_id].tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function ConfirmPasskeyScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Confirm Passkey',
         }}

--- a/apps/expo/app/account/backup/create.tsx
+++ b/apps/expo/app/account/backup/create.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function CreatePasskeyScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Create Passkey',
         }}

--- a/apps/expo/app/account/backup/index.tsx
+++ b/apps/expo/app/account/backup/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 
 export default function AccountScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Passkeys',
         }}

--- a/apps/expo/app/account/edit-profile.tsx
+++ b/apps/expo/app/account/edit-profile.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function ProfileScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Profile',
         }}

--- a/apps/expo/app/account/index.tsx
+++ b/apps/expo/app/account/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 
 export default function AccountScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Account',
         }}

--- a/apps/expo/app/account/personal-info.tsx
+++ b/apps/expo/app/account/personal-info.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function PersonalInfoScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Personal information',
         }}

--- a/apps/expo/app/account/sendtag/add.tsx
+++ b/apps/expo/app/account/sendtag/add.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function AddSendtagsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Register Sendtags',
         }}

--- a/apps/expo/app/account/sendtag/checkout.tsx
+++ b/apps/expo/app/account/sendtag/checkout.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function CheckoutSendtagsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Checkout',
         }}

--- a/apps/expo/app/account/sendtag/first.tsx
+++ b/apps/expo/app/account/sendtag/first.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function FirstSendtagScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'First Sendtag',
         }}

--- a/apps/expo/app/account/sendtag/index.tsx
+++ b/apps/expo/app/account/sendtag/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 
 export default function SendtagsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Sendtags',
         }}

--- a/apps/expo/app/deposit/apple-pay.tsx
+++ b/apps/expo/app/deposit/apple-pay.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function ApplePayDepositScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Apple Pay',
         }}

--- a/apps/expo/app/deposit/crypto.tsx
+++ b/apps/expo/app/deposit/crypto.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function CryptoDepositScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Deposit on Base',
         }}

--- a/apps/expo/app/deposit/debit-card.tsx
+++ b/apps/expo/app/deposit/debit-card.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function DebitCardDepositScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Debit Card',
         }}

--- a/apps/expo/app/deposit/index.tsx
+++ b/apps/expo/app/deposit/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 
 export default function DepositScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Deposit',
         }}

--- a/apps/expo/app/deposit/success.tsx
+++ b/apps/expo/app/deposit/success.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function SuccessDepositScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Success Deposit',
         }}

--- a/apps/expo/app/earn/[asset]/balance.tsx
+++ b/apps/expo/app/earn/[asset]/balance.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function BalanceAssetSavingsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Savings Balance',
         }}

--- a/apps/expo/app/earn/[asset]/deposit.tsx
+++ b/apps/expo/app/earn/[asset]/deposit.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function DepositAssetSavingsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Start Saving',
         }}

--- a/apps/expo/app/earn/[asset]/index.tsx
+++ b/apps/expo/app/earn/[asset]/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 
 export default function SavingsAssetScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Savings',
         }}

--- a/apps/expo/app/earn/[asset]/withdraw.tsx
+++ b/apps/expo/app/earn/[asset]/withdraw.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function WithdrawAssetSavingsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Withdraw Savings',
         }}

--- a/apps/expo/app/earn/index.tsx
+++ b/apps/expo/app/earn/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 
 export default function SavingsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Savings',
         }}

--- a/apps/expo/app/feed/index.tsx
+++ b/apps/expo/app/feed/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Paragraph } from '@my/ui'
 
 export default function FeedScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Community Feed',
         }}

--- a/apps/expo/app/profile/[sendid].tsx
+++ b/apps/expo/app/profile/[sendid].tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Paragraph } from '@my/ui'
 
 export default function ProfileScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'History',
         }}

--- a/apps/expo/app/rewards/index.tsx
+++ b/apps/expo/app/rewards/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Paragraph } from '@my/ui'
 
 export default function RewardsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Rewards',
         }}

--- a/apps/expo/app/sendpot/buy-tickets.tsx
+++ b/apps/expo/app/sendpot/buy-tickets.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function BuySendpotTicketsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Buy Tickets',
         }}

--- a/apps/expo/app/sendpot/confirm-buy-tickets.tsx
+++ b/apps/expo/app/sendpot/confirm-buy-tickets.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function ConfirmBuySendpotTicketsScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Buy Tickets Summary',
         }}

--- a/apps/expo/app/sendpot/index.tsx
+++ b/apps/expo/app/sendpot/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 
 export default function SendpotScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Sendpot',
         }}

--- a/apps/expo/app/trade/index.tsx
+++ b/apps/expo/app/trade/index.tsx
@@ -1,11 +1,11 @@
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
-import { Stack as StackRouter } from 'expo-router'
+import { Stack } from 'expo-router'
 import { Link, Paragraph } from '@my/ui'
 
 export default function TradeScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Trade',
         }}

--- a/apps/expo/app/trade/summary.tsx
+++ b/apps/expo/app/trade/summary.tsx
@@ -1,11 +1,11 @@
-import { Stack as StackRouter } from 'expo-router/build/layouts/Stack'
+import { Stack } from 'expo-router/build/layouts/Stack'
 import { ScreenContainer } from 'apps-expo/components/layout/ScreenContainer'
 import { Paragraph } from '@my/ui'
 
 export default function TradeSummaryScreen() {
   return (
     <>
-      <StackRouter.Screen
+      <Stack.Screen
         options={{
           title: 'Trade summary',
         }}


### PR DESCRIPTION
## Summary 

Refactor `Stack` imports from `expo-router` to simplify the codebase.


## Changes Made

- Refactor `Stack` imports in multiple files
- Replace `StackRouter` with `Stack`
- Update import statements for consistency

_written by Kolwaii, your beloved blockchain engineer AI agent_