### PR TITLE
Modify send score row security

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -36,6 +36,7 @@ schema_paths = [
   "./schemas/referrals.sql",
   "./schemas/distributions.sql",
   "./schemas/send_earn.sql",
+  "./schemas/send_scores.sql",
 
   # Send account related tables
   "./schemas/send_account_created.sql",

--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -165,13 +165,6 @@ export type Database = {
             referencedRelation: "send_scores_current"
             referencedColumns: ["distribution_id"]
           },
-          {
-            foreignKeyName: "distribution_shares_distribution_id_fkey"
-            columns: ["distribution_id"]
-            isOneToOne: false
-            referencedRelation: "send_scores_history"
-            referencedColumns: ["distribution_id"]
-          },
         ]
       }
       distribution_verification_values: {
@@ -221,13 +214,6 @@ export type Database = {
             columns: ["distribution_id"]
             isOneToOne: false
             referencedRelation: "send_scores_current"
-            referencedColumns: ["distribution_id"]
-          },
-          {
-            foreignKeyName: "distribution_verification_values_distribution_id_fkey"
-            columns: ["distribution_id"]
-            isOneToOne: false
-            referencedRelation: "send_scores_history"
             referencedColumns: ["distribution_id"]
           },
         ]
@@ -280,13 +266,6 @@ export type Database = {
             columns: ["distribution_id"]
             isOneToOne: false
             referencedRelation: "send_scores_current"
-            referencedColumns: ["distribution_id"]
-          },
-          {
-            foreignKeyName: "distribution_verifications_distribution_id_fkey"
-            columns: ["distribution_id"]
-            isOneToOne: false
-            referencedRelation: "send_scores_history"
             referencedColumns: ["distribution_id"]
           },
         ]
@@ -1207,13 +1186,6 @@ export type Database = {
             referencedRelation: "send_scores_current"
             referencedColumns: ["distribution_id"]
           },
-          {
-            foreignKeyName: "send_slash_distribution_id_fkey"
-            columns: ["distribution_id"]
-            isOneToOne: false
-            referencedRelation: "send_scores_history"
-            referencedColumns: ["distribution_id"]
-          },
         ]
       }
       send_token_transfers: {
@@ -1736,16 +1708,6 @@ export type Database = {
         }
         Relationships: []
       }
-      send_scores_history: {
-        Row: {
-          distribution_id: number | null
-          score: number | null
-          send_ceiling: number | null
-          unique_sends: number | null
-          user_id: string | null
-        }
-        Relationships: []
-      }
     }
     Functions: {
       calculate_and_insert_send_ceiling_verification: {
@@ -1850,6 +1812,16 @@ export type Database = {
       get_pending_jackpot_tickets_purchased: {
         Args: Record<PropertyKey, never>
         Returns: number
+      }
+      get_send_scores_history: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          user_id: string
+          distribution_id: number
+          score: number
+          unique_sends: number
+          send_ceiling: number
+        }[]
       }
       get_user_jackpot_summary: {
         Args: { num_runs: number }

--- a/supabase/migrations/20250614002319_patch_security_send_score_views.sql
+++ b/supabase/migrations/20250614002319_patch_security_send_score_views.sql
@@ -1,0 +1,599 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION private.get_send_score(addr bytea)
+ RETURNS TABLE(distribution_id integer, score numeric, unique_sends bigint, send_ceiling numeric)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+BEGIN
+    RETURN QUERY
+    WITH active_distribution AS (
+        SELECT
+            d.id,
+            d.number,
+            EXTRACT(epoch FROM d.qualification_start) AS start_time,
+            EXTRACT(epoch FROM d.qualification_end) AS end_time,
+            d.hodler_min_balance,
+            d.earn_min_balance,
+            d.token_addr,
+            ss.minimum_sends,
+            ss.scaling_divisor,
+            (SELECT distributions.id FROM distributions WHERE distributions.number = (d.number - 1)) AS prev_distribution_id
+        FROM distributions d
+        JOIN send_slash ss ON ss.distribution_id = d.id
+        WHERE now() AT TIME ZONE 'UTC' >= d.qualification_start
+        AND now() AT TIME ZONE 'UTC' < d.qualification_end
+        LIMIT 1
+    ),
+    send_ceiling AS (
+        SELECT
+            ad.id AS distribution_id,
+            ROUND((
+                COALESCE(
+                    (SELECT
+                        CASE
+                            WHEN d.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea
+                            THEN ds.amount * '10000000000000000'::numeric
+                            ELSE ds.amount
+                        END
+                    FROM distribution_shares ds
+                    JOIN distributions d ON d.id = ds.distribution_id
+                    JOIN send_accounts sa ON sa.user_id = ds.user_id
+                    WHERE ds.distribution_id = ad.prev_distribution_id
+                    AND sa.address = concat('0x', encode(addr, 'hex'))::citext),
+                    CASE
+                        WHEN ad.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea
+                        THEN ad.hodler_min_balance * '10000000000000000'::numeric
+                        ELSE ad.hodler_min_balance
+                    END
+                ) / (ad.minimum_sends * ad.scaling_divisor)
+            ))::numeric AS send_ceiling,
+            ad.earn_min_balance,
+            ad.start_time,
+            ad.end_time
+        FROM active_distribution ad
+    ),
+    earn_balances_timeline AS (
+        SELECT owner,
+            block_time,
+            sum(balance) OVER w AS balance,
+            lead(block_time) OVER w AS next_block_time
+        FROM (
+            SELECT owner, block_time, assets AS balance
+            FROM send_earn_deposit
+            UNION ALL
+            SELECT owner, block_time, -assets
+            FROM send_earn_withdraw
+        ) earn_data
+        WINDOW w AS (PARTITION BY owner ORDER BY block_time ROWS UNBOUNDED PRECEDING)
+    )
+    SELECT
+        sc.distribution_id,
+        SUM(LEAST(transfer_sums.amount, sc.send_ceiling)) as score,
+        COUNT(DISTINCT transfer_sums.t) as unique_sends,
+        sc.send_ceiling
+    FROM send_ceiling sc
+    LEFT JOIN LATERAL (
+        SELECT t, SUM(v) as amount
+        FROM (
+            SELECT
+                stt.t,
+                stt.v,
+                stt.block_time
+            FROM send_token_transfers stt
+            WHERE stt.f = addr
+            AND stt.block_time >= sc.start_time
+            AND stt.block_time <= sc.end_time
+            UNION ALL
+            SELECT
+                stv.t,
+                stv.v * '10000000000000000'::numeric,
+                stv.block_time
+            FROM send_token_v0_transfers stv
+            WHERE stv.f = addr
+            AND stv.block_time >= sc.start_time
+            AND stv.block_time <= sc.end_time
+        ) transfers
+        WHERE sc.earn_min_balance = 0
+        OR EXISTS (
+            SELECT 1
+            FROM earn_balances_timeline ebt
+            WHERE ebt.owner = transfers.t
+            AND ebt.balance >= sc.earn_min_balance
+            AND ebt.block_time <= transfers.block_time
+            AND (ebt.next_block_time IS NULL OR transfers.block_time < ebt.next_block_time)
+        )
+        GROUP BY t
+    ) transfer_sums ON true
+    GROUP BY sc.distribution_id, sc.send_ceiling
+    HAVING SUM(LEAST(transfer_sums.amount, sc.send_ceiling)) > 0;
+END;
+$function$
+;
+
+create materialized view "private"."send_scores_history" as  WITH distributions_with_score AS (
+         SELECT d.id,
+            d.number,
+            EXTRACT(epoch FROM d.qualification_start) AS start_time,
+            EXTRACT(epoch FROM d.qualification_end) AS end_time,
+            d.hodler_min_balance,
+            d.earn_min_balance,
+            d.token_addr,
+            ss.minimum_sends,
+            ss.scaling_divisor,
+            ( SELECT distributions.id
+                   FROM distributions
+                  WHERE (distributions.number = (d.number - 1))) AS prev_distribution_id
+           FROM (distributions d
+             JOIN send_slash ss ON ((ss.distribution_id = d.id)))
+          WHERE (d.qualification_end < (now() AT TIME ZONE 'UTC'::text))
+        ), previous_shares AS (
+         SELECT ds.user_id,
+            dws.id AS next_distribution_id,
+                CASE
+                    WHEN (d.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea) THEN (ds.amount * '10000000000000000'::numeric)
+                    ELSE ds.amount
+                END AS adjusted_amount
+           FROM ((distributions_with_score dws
+             JOIN distribution_shares ds ON ((ds.distribution_id = dws.prev_distribution_id)))
+             JOIN distributions d ON ((d.id = ds.distribution_id)))
+        ), send_ceiling_settings AS (
+         SELECT sa.user_id,
+            decode(replace(sa.address, '0x'::citext, ''::citext), 'hex'::text) AS address,
+            dws.id AS distribution_id,
+            round((COALESCE(ps.adjusted_amount,
+                CASE
+                    WHEN (dws.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea) THEN (dws.hodler_min_balance * '10000000000000000'::numeric)
+                    ELSE dws.hodler_min_balance
+                END) / ((dws.minimum_sends * dws.scaling_divisor))::numeric)) AS send_ceiling
+           FROM ((send_accounts sa
+             CROSS JOIN distributions_with_score dws)
+             LEFT JOIN previous_shares ps ON (((ps.user_id = sa.user_id) AND (ps.next_distribution_id = dws.id))))
+        ), earn_balances AS (
+         SELECT send_earn_balances_timeline.owner,
+            send_earn_balances_timeline.block_time,
+            send_earn_balances_timeline.balance,
+            lead(send_earn_balances_timeline.block_time) OVER (PARTITION BY send_earn_balances_timeline.owner ORDER BY send_earn_balances_timeline.block_time) AS next_block_time
+           FROM send_earn_balances_timeline
+        ), filtered_transfers AS (
+         SELECT transfers.f,
+            transfers.t,
+            transfers.v,
+            transfers.block_time,
+            dws.id AS distribution_id
+           FROM ( SELECT min(distributions_with_score.start_time) AS min_start,
+                    max(distributions_with_score.end_time) AS max_end
+                   FROM distributions_with_score) bounds,
+            LATERAL ( SELECT send_token_transfers.f,
+                    send_token_transfers.t,
+                    send_token_transfers.v,
+                    send_token_transfers.block_time
+                   FROM send_token_transfers
+                  WHERE ((send_token_transfers.block_time >= bounds.min_start) AND (send_token_transfers.block_time <= bounds.max_end))
+                UNION ALL
+                 SELECT send_token_v0_transfers.f,
+                    send_token_v0_transfers.t,
+                    (send_token_v0_transfers.v * '10000000000000000'::numeric),
+                    send_token_v0_transfers.block_time
+                   FROM send_token_v0_transfers
+                  WHERE ((send_token_v0_transfers.block_time >= bounds.min_start) AND (send_token_v0_transfers.block_time <= bounds.max_end))) transfers,
+            distributions_with_score dws
+          WHERE ((transfers.block_time >= dws.start_time) AND (transfers.block_time <= dws.end_time) AND ((dws.earn_min_balance = 0) OR (EXISTS ( SELECT 1
+                   FROM earn_balances eb
+                  WHERE ((eb.owner = transfers.t) AND (eb.block_time <= eb.block_time) AND ((eb.next_block_time IS NULL) OR (eb.block_time < eb.next_block_time)) AND (COALESCE(eb.balance, (0)::numeric) >= (dws.earn_min_balance)::numeric))))))
+        )
+ SELECT scs.user_id,
+    scs.distribution_id,
+    scores.score,
+    scores.unique_sends,
+    scs.send_ceiling
+   FROM (( SELECT grouped_transfers.f AS address,
+            grouped_transfers.distribution_id,
+            sum(LEAST(grouped_transfers.transfer_sum, grouped_transfers.send_ceiling)) AS score,
+            count(DISTINCT grouped_transfers.t) AS unique_sends
+           FROM ( SELECT ft.f,
+                    ft.distribution_id,
+                    ft.t,
+                    sum(ft.v) AS transfer_sum,
+                    scs_1.send_ceiling
+                   FROM (filtered_transfers ft
+                     JOIN send_ceiling_settings scs_1 ON (((ft.f = scs_1.address) AND (ft.distribution_id = scs_1.distribution_id))))
+                  GROUP BY ft.f, ft.t, ft.distribution_id, scs_1.send_ceiling) grouped_transfers
+          GROUP BY grouped_transfers.f, grouped_transfers.distribution_id
+         HAVING (sum(LEAST(grouped_transfers.transfer_sum, grouped_transfers.send_ceiling)) > (0)::numeric)) scores
+     JOIN send_ceiling_settings scs ON (((scores.address = scs.address) AND (scores.distribution_id = scs.distribution_id))));
+
+
+CREATE UNIQUE INDEX send_scores_history_user_id_distribution_id_idx ON private.send_scores_history USING btree (user_id, distribution_id);
+
+
+drop index if exists "public"."send_scores_history_user_id_distribution_id_idx";
+
+drop view if exists "public"."send_scores";
+
+drop materialized view if exists "public"."send_scores_history";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_send_scores_history()
+ RETURNS TABLE(user_id uuid, distribution_id integer, score numeric, unique_sends bigint, send_ceiling numeric)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+
+BEGIN
+    IF auth.role() = 'authenticated' THEN
+        RETURN QUERY SELECT * FROM private.send_scores_history WHERE send_scores_history.user_id = (select auth.uid());
+    ELSE
+        RETURN QUERY SELECT * FROM private.send_scores_history;
+    END IF;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.insert_verification_send_ceiling()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+    -- Exit early if value is not positive
+    IF NOT (NEW.v > 0) THEN
+        RETURN NEW;
+    END IF;
+
+    -- Try to update existing verification
+    UPDATE distribution_verifications dv
+    SET
+        weight = s.score,
+        metadata = jsonb_build_object('value', s.send_ceiling::text)
+    FROM private.get_send_score(NEW.f) s
+    CROSS JOIN (
+        SELECT user_id
+        FROM send_accounts
+        WHERE address = concat('0x', encode(NEW.f, 'hex'))::citext
+    ) sa
+    WHERE dv.user_id = sa.user_id
+        AND dv.distribution_id = s.distribution_id
+        AND dv.type = 'send_ceiling';
+
+    -- If no row was updated, insert new verification
+    IF NOT FOUND THEN
+        INSERT INTO distribution_verifications(
+            distribution_id,
+            user_id,
+            type,
+            weight,
+            metadata
+        )
+        SELECT
+            s.distribution_id,
+            sa.user_id,
+            'send_ceiling',
+            s.score,
+            jsonb_build_object('value', s.send_ceiling::text)
+        FROM private.get_send_score(NEW.f) s
+        CROSS JOIN (
+            SELECT user_id
+            FROM send_accounts
+            WHERE address = concat('0x', encode(NEW.f, 'hex'))::citext
+        ) sa
+        WHERE s.score > 0;
+    END IF;
+
+    RETURN NEW;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE NOTICE 'Error in insert_verification_send_ceiling: %', SQLERRM;
+        RETURN NEW;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.insert_verification_sends()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+    -- Update existing verifications
+    UPDATE public.distribution_verifications dv
+    SET metadata = jsonb_build_object('value', s.unique_sends),
+        weight = CASE
+            WHEN dv.type = 'send_ten' AND s.unique_sends >= 10 THEN 1
+            WHEN dv.type = 'send_one_hundred' AND s.unique_sends >= 100 THEN 1
+            ELSE 0
+        END,
+        created_at = to_timestamp(NEW.block_time) at time zone 'UTC'
+    FROM private.get_send_score(NEW.f) s
+    JOIN send_accounts sa ON sa.address = concat('0x', encode(NEW.f, 'hex'))::citext
+    WHERE dv.distribution_id = s.distribution_id
+        AND dv.user_id = sa.user_id
+        AND dv.type IN ('send_ten', 'send_one_hundred');
+
+    -- Insert new verifications if they don't exist
+    INSERT INTO public.distribution_verifications(
+        distribution_id,
+        user_id,
+        type,
+        metadata,
+        weight,
+        created_at
+    )
+    SELECT
+        s.distribution_id,
+        sa.user_id,
+        v.type,
+        jsonb_build_object('value', s.unique_sends),
+        CASE
+            WHEN v.type = 'send_ten' AND s.unique_sends >= 10 THEN 1
+            WHEN v.type = 'send_one_hundred' AND s.unique_sends >= 100 THEN 1
+            ELSE 0
+        END,
+        to_timestamp(NEW.block_time) at time zone 'UTC'
+    FROM private.get_send_score(NEW.f) s
+    JOIN send_accounts sa ON sa.address = concat('0x', encode(NEW.f, 'hex'))::citext
+    CROSS JOIN (
+        VALUES
+            ('send_ten'::verification_type),
+            ('send_one_hundred'::verification_type)
+    ) v(type)
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM distribution_verifications dv
+        WHERE dv.user_id = sa.user_id
+            AND dv.distribution_id = s.distribution_id
+            AND dv.type = v.type
+    );
+
+    RETURN NEW;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.refresh_send_scores_history()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY private.send_scores_history;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.refresh_send_scores_history_trigger()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  PERFORM refresh_send_scores_history();
+  RETURN NEW;
+END;
+$function$
+;
+
+create or replace view "public"."send_scores_current" as  WITH authorized_user AS (
+         SELECT auth.uid() AS user_id
+        ), distributions_with_score AS (
+         SELECT d.id,
+            d.number,
+            EXTRACT(epoch FROM d.qualification_start) AS start_time,
+            EXTRACT(epoch FROM d.qualification_end) AS end_time,
+            d.hodler_min_balance,
+            d.earn_min_balance,
+            d.token_addr,
+            ss.minimum_sends,
+            ss.scaling_divisor,
+            ( SELECT distributions.id
+                   FROM distributions
+                  WHERE (distributions.number = (d.number - 1))) AS prev_distribution_id
+           FROM (distributions d
+             JOIN send_slash ss ON ((ss.distribution_id = d.id)))
+          WHERE (((now() AT TIME ZONE 'UTC'::text) >= d.qualification_start) AND ((now() AT TIME ZONE 'UTC'::text) < d.qualification_end))
+         LIMIT 1
+        ), base_ceiling AS (
+         SELECT dws.id AS distribution_id,
+                CASE
+                    WHEN (dws.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea) THEN (dws.hodler_min_balance * '10000000000000000'::numeric)
+                    ELSE dws.hodler_min_balance
+                END AS base_amount,
+            dws.minimum_sends,
+            dws.scaling_divisor,
+            dws.prev_distribution_id,
+            dws.earn_min_balance,
+            dws.start_time,
+            dws.end_time
+           FROM distributions_with_score dws
+        ), authorized_accounts AS (
+         SELECT sa.user_id,
+            decode(replace((sa.address)::text, ('0x'::citext)::text, ''::text), 'hex'::text) AS address_bytes
+           FROM (send_accounts sa
+             CROSS JOIN authorized_user au)
+          WHERE ((au.user_id IS NULL) OR (sa.user_id = au.user_id))
+        ), authorized_distribution_shares AS (
+         SELECT ds.user_id,
+                CASE
+                    WHEN (d.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea) THEN (ds.amount * '10000000000000000'::numeric)
+                    ELSE ds.amount
+                END AS adjusted_amount
+           FROM (((base_ceiling bc
+             JOIN distribution_shares ds ON ((ds.distribution_id = bc.prev_distribution_id)))
+             JOIN distributions d ON ((d.id = ds.distribution_id)))
+             JOIN authorized_accounts aa ON ((aa.user_id = ds.user_id)))
+        ), send_ceiling_settings AS (
+         SELECT aa.user_id,
+            aa.address_bytes AS address,
+            bc.distribution_id,
+            round((COALESCE(ads.adjusted_amount, bc.base_amount) / ((bc.minimum_sends * bc.scaling_divisor))::numeric)) AS send_ceiling
+           FROM ((base_ceiling bc
+             CROSS JOIN authorized_accounts aa)
+             LEFT JOIN authorized_distribution_shares ads ON ((ads.user_id = aa.user_id)))
+        ), earn_balances_timeline AS (
+         SELECT earn_data.owner,
+            earn_data.block_time,
+            sum(earn_data.balance) OVER w AS balance,
+            lead(earn_data.block_time) OVER w AS next_block_time
+           FROM ( SELECT send_earn_deposit.owner,
+                    send_earn_deposit.block_time,
+                    send_earn_deposit.assets AS balance
+                   FROM send_earn_deposit
+                UNION ALL
+                 SELECT send_earn_withdraw.owner,
+                    send_earn_withdraw.block_time,
+                    (- send_earn_withdraw.assets)
+                   FROM send_earn_withdraw) earn_data
+          WINDOW w AS (PARTITION BY earn_data.owner ORDER BY earn_data.block_time ROWS UNBOUNDED PRECEDING)
+        ), transfer_sums AS (
+         SELECT transfers.f,
+            bc.distribution_id,
+            transfers.t,
+            sum(transfers.v) AS transfer_sum
+           FROM (base_ceiling bc
+             CROSS JOIN LATERAL ( SELECT stt.f,
+                    stt.t,
+                    stt.v,
+                    stt.block_time
+                   FROM send_token_transfers stt
+                  WHERE ((stt.block_time >= bc.start_time) AND (stt.block_time <= bc.end_time) AND (stt.f IN ( SELECT authorized_accounts.address_bytes
+                           FROM authorized_accounts)))
+                UNION ALL
+                 SELECT stv.f,
+                    stv.t,
+                    (stv.v * '10000000000000000'::numeric),
+                    stv.block_time
+                   FROM send_token_v0_transfers stv
+                  WHERE ((stv.block_time >= bc.start_time) AND (stv.block_time <= bc.end_time) AND (stv.f IN ( SELECT authorized_accounts.address_bytes
+                           FROM authorized_accounts)))) transfers)
+          WHERE ((bc.earn_min_balance = 0) OR (EXISTS ( SELECT 1
+                   FROM earn_balances_timeline ebt
+                  WHERE ((ebt.owner = transfers.t) AND (ebt.balance >= (bc.earn_min_balance)::numeric) AND (ebt.block_time <= transfers.block_time) AND ((ebt.next_block_time IS NULL) OR (transfers.block_time < ebt.next_block_time))))))
+          GROUP BY transfers.f, bc.distribution_id, transfers.t
+        )
+ SELECT scs.user_id,
+    scs.distribution_id,
+    scores.score,
+    scores.unique_sends,
+    scs.send_ceiling
+   FROM (( SELECT ts.f AS address,
+            ts.distribution_id,
+            sum(LEAST(ts.transfer_sum, scs_1.send_ceiling)) AS score,
+            count(DISTINCT ts.t) AS unique_sends
+           FROM (transfer_sums ts
+             JOIN send_ceiling_settings scs_1 ON (((ts.f = scs_1.address) AND (ts.distribution_id = scs_1.distribution_id))))
+          GROUP BY ts.f, ts.distribution_id
+         HAVING (sum(LEAST(ts.transfer_sum, scs_1.send_ceiling)) > (0)::numeric)) scores
+     JOIN send_ceiling_settings scs ON (((scores.address = scs.address) AND (scores.distribution_id = scs.distribution_id))));
+
+
+create or replace view "public"."send_scores" as  SELECT get_send_scores_history.user_id,
+    get_send_scores_history.distribution_id,
+    get_send_scores_history.score,
+    get_send_scores_history.unique_sends,
+    get_send_scores_history.send_ceiling
+   FROM get_send_scores_history() get_send_scores_history(user_id, distribution_id, score, unique_sends, send_ceiling)
+UNION ALL
+ SELECT send_scores_current.user_id,
+    send_scores_current.distribution_id,
+    send_scores_current.score,
+    send_scores_current.unique_sends,
+    send_scores_current.send_ceiling
+   FROM send_scores_current;
+
+REVOKE ALL ON FUNCTION "public"."calculate_and_insert_send_ceiling_verification"("distribution_number" integer) FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."calculate_and_insert_send_ceiling_verification"("distribution_number" integer) TO "service_role";
+-- Revoke all public and authenticated access, grant only to service_role
+-- For all functions:
+
+REVOKE ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_verification_sends"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_verification_sends"() FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_verification_sends"() TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_verification_send_ceiling"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_verification_send_ceiling"() FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_verification_send_ceiling"() TO service_role;
+
+REVOKE ALL ON FUNCTION "public"."insert_verification_send_ceiling"() FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."insert_verification_send_ceiling"() TO service_role;
+
+ALTER MATERIALIZED VIEW "private"."send_scores_history" OWNER TO postgres;
+ALTER VIEW "public"."send_scores_current_unique" OWNER TO postgres;
+ALTER VIEW "public"."send_scores_current" OWNER TO postgres;
+ALTER VIEW "public"."send_scores" OWNER TO postgres;
+
+
+REVOKE ALL ON "private"."send_scores_history" FROM PUBLIC;
+REVOKE ALL ON "private"."send_scores_history" FROM authenticated;
+GRANT ALL ON "private"."send_scores_history" TO service_role;
+
+REVOKE ALL ON "public"."send_scores_current_unique" FROM PUBLIC;
+GRANT ALL ON "public"."send_scores_current_unique" TO service_role;
+GRANT ALL ON "public"."send_scores_current_unique" TO authenticated;
+
+REVOKE ALL ON "public"."send_scores_current" FROM PUBLIC;
+GRANT ALL ON "public"."send_scores_current" TO service_role;
+GRANT ALL ON "public"."send_scores_current" TO authenticated;
+
+REVOKE ALL ON "public"."send_scores" FROM PUBLIC;
+GRANT ALL ON "public"."send_scores" TO service_role;
+GRANT ALL ON "public"."send_scores" TO authenticated;
+
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() FROM authenticated;
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() FROM anon;
+GRANT ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() TO service_role;
+
+
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history"() FROM authenticated;
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history"() FROM anon;
+GRANT ALL ON FUNCTION "public"."refresh_send_scores_history"() TO service_role;
+
+
+REVOKE ALL ON FUNCTION "public"."get_send_scores_history"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."get_send_scores_history"() FROM anon;
+GRANT ALL ON FUNCTION "public"."get_send_scores_history"() TO authenticated;
+GRANT ALL ON FUNCTION "public"."get_send_scores_history"() TO service_role;
+
+REVOKE ALL ON FUNCTION "private"."get_send_score"(addr bytea) FROM PUBLIC;
+GRANT ALL ON FUNCTION "private"."get_send_score"(addr bytea) TO service_role;

--- a/supabase/schemas/distributions.sql
+++ b/supabase/schemas/distributions.sql
@@ -852,6 +852,132 @@ $function$;
 
 ALTER FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) OWNER TO "postgres";
 
+CREATE OR REPLACE FUNCTION public.insert_verification_sends()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+    -- Update existing verifications
+    UPDATE public.distribution_verifications dv
+    SET metadata = jsonb_build_object('value', s.unique_sends),
+        weight = CASE
+            WHEN dv.type = 'send_ten' AND s.unique_sends >= 10 THEN 1
+            WHEN dv.type = 'send_one_hundred' AND s.unique_sends >= 100 THEN 1
+            ELSE 0
+        END,
+        created_at = to_timestamp(NEW.block_time) at time zone 'UTC'
+    FROM private.get_send_score(NEW.f) s
+    JOIN send_accounts sa ON sa.address = concat('0x', encode(NEW.f, 'hex'))::citext
+    WHERE dv.distribution_id = s.distribution_id
+        AND dv.user_id = sa.user_id
+        AND dv.type IN ('send_ten', 'send_one_hundred');
+
+    -- Insert new verifications if they don't exist
+    INSERT INTO public.distribution_verifications(
+        distribution_id,
+        user_id,
+        type,
+        metadata,
+        weight,
+        created_at
+    )
+    SELECT
+        s.distribution_id,
+        sa.user_id,
+        v.type,
+        jsonb_build_object('value', s.unique_sends),
+        CASE
+            WHEN v.type = 'send_ten' AND s.unique_sends >= 10 THEN 1
+            WHEN v.type = 'send_one_hundred' AND s.unique_sends >= 100 THEN 1
+            ELSE 0
+        END,
+        to_timestamp(NEW.block_time) at time zone 'UTC'
+    FROM private.get_send_score(NEW.f) s
+    JOIN send_accounts sa ON sa.address = concat('0x', encode(NEW.f, 'hex'))::citext
+    CROSS JOIN (
+        VALUES
+            ('send_ten'::verification_type),
+            ('send_one_hundred'::verification_type)
+    ) v(type)
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM distribution_verifications dv
+        WHERE dv.user_id = sa.user_id
+            AND dv.distribution_id = s.distribution_id
+            AND dv.type = v.type
+    );
+
+    RETURN NEW;
+END;
+$function$
+;
+
+ALTER FUNCTION "public"."insert_verification_sends"() OWNER TO "postgres";
+
+CREATE OR REPLACE FUNCTION public.insert_verification_send_ceiling()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+    -- Exit early if value is not positive
+    IF NOT (NEW.v > 0) THEN
+        RETURN NEW;
+    END IF;
+
+    -- Try to update existing verification
+    UPDATE distribution_verifications dv
+    SET
+        weight = s.score,
+        metadata = jsonb_build_object('value', s.send_ceiling::text)
+    FROM private.get_send_score(NEW.f) s
+    CROSS JOIN (
+        SELECT user_id
+        FROM send_accounts
+        WHERE address = concat('0x', encode(NEW.f, 'hex'))::citext
+    ) sa
+    WHERE dv.user_id = sa.user_id
+        AND dv.distribution_id = s.distribution_id
+        AND dv.type = 'send_ceiling';
+
+    -- If no row was updated, insert new verification
+    IF NOT FOUND THEN
+        INSERT INTO distribution_verifications(
+            distribution_id,
+            user_id,
+            type,
+            weight,
+            metadata
+        )
+        SELECT
+            s.distribution_id,
+            sa.user_id,
+            'send_ceiling',
+            s.score,
+            jsonb_build_object('value', s.send_ceiling::text)
+        FROM private.get_send_score(NEW.f) s
+        CROSS JOIN (
+            SELECT user_id
+            FROM send_accounts
+            WHERE address = concat('0x', encode(NEW.f, 'hex'))::citext
+        ) sa
+        WHERE s.score > 0;
+    END IF;
+
+    RETURN NEW;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE NOTICE 'Error in insert_verification_send_ceiling: %', SQLERRM;
+        RETURN NEW;
+END;
+$function$
+;
+
+ALTER FUNCTION "public"."insert_verification_send_ceiling"() OWNER TO "postgres";
+
 -- Grants for tables
 GRANT ALL ON TABLE "public"."distributions" TO "anon";
 GRANT ALL ON TABLE "public"."distributions" TO "authenticated";
@@ -910,237 +1036,52 @@ CREATE POLICY "Enable read access for all users" ON "public"."send_slash" FOR SE
 -- Function grants
 REVOKE ALL ON FUNCTION "public"."calculate_and_insert_send_ceiling_verification"("distribution_number" integer) FROM PUBLIC;
 GRANT ALL ON FUNCTION "public"."calculate_and_insert_send_ceiling_verification"("distribution_number" integer) TO "service_role";
+-- Revoke all public and authenticated access, grant only to service_role
+-- For all functions:
 
 REVOKE ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_create_passkey_verifications"("distribution_num" integer) TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_send_slash"("distribution_number" integer, "scaling_divisor" integer, "minimum_sends" integer) TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_send_streak_verifications"("distribution_num" integer) TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_send_verifications"("distribution_num" integer) TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_tag_referral_verifications"("distribution_num" integer) TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_tag_registration_verifications"("distribution_num" integer) TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_total_referral_verifications"("distribution_num" integer) TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) TO "service_role";
-
-REVOKE ALL ON FUNCTION "public"."update_distribution_shares"("distribution_id" integer, "shares" "public"."distribution_shares"[]) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."update_distribution_shares"("distribution_id" integer, "shares" "public"."distribution_shares"[]) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_verification_value"("distribution_number" integer, "type" "public"."verification_type", "fixed_value" numeric, "bips_value" integer, "multiplier_min" numeric, "multiplier_max" numeric, "multiplier_step" numeric) TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) TO "anon";
-GRANT ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) TO "authenticated";
-GRANT ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) TO "service_role";
+REVOKE ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) FROM authenticated;
+GRANT ALL ON FUNCTION "public"."update_referral_verifications"("distribution_id" integer, "shares" "public"."distribution_shares"[]) TO service_role;
 
-CREATE OR REPLACE FUNCTION public.insert_verification_sends()
- RETURNS trigger
- LANGUAGE plpgsql
- SECURITY DEFINER
- SET search_path TO 'public'
-AS $function$
-DECLARE
-    score_record RECORD;
-BEGIN
-    -- Calculate send_scores_current only once by getting the score for this sender
-    SELECT ss.distribution_id, ss.user_id, ss.unique_sends
-    INTO score_record
-    FROM send_scores_current ss
-    JOIN send_accounts sa ON sa.user_id = ss.user_id
-    WHERE sa.address = concat('0x', encode(NEW.f, 'hex'))::citext;
-
-    -- Early exit if no score found
-    IF NOT FOUND THEN
-        RETURN NEW;
-    END IF;
-
-    -- Update existing verifications
-    UPDATE public.distribution_verifications dv
-    SET metadata = jsonb_build_object('value', score_record.unique_sends),
-        weight = CASE
-            WHEN dv.type = 'send_ten' AND score_record.unique_sends >= 10 THEN 1
-            WHEN dv.type = 'send_one_hundred' AND score_record.unique_sends >= 100 THEN 1
-            ELSE 0
-        END,
-        created_at = to_timestamp(NEW.block_time) at time zone 'UTC'
-    WHERE dv.distribution_id = score_record.distribution_id
-        AND dv.user_id = score_record.user_id
-        AND dv.type IN ('send_ten', 'send_one_hundred');
-
-    -- Insert new verifications if they don't exist
-    INSERT INTO public.distribution_verifications(
-        distribution_id,
-        user_id,
-        type,
-        metadata,
-        weight,
-        created_at
-    )
-    SELECT
-        score_record.distribution_id,
-        score_record.user_id,
-        v.type,
-        jsonb_build_object('value', score_record.unique_sends),
-        CASE
-            WHEN v.type = 'send_ten' AND score_record.unique_sends >= 10 THEN 1
-            WHEN v.type = 'send_one_hundred' AND score_record.unique_sends >= 100 THEN 1
-            ELSE 0
-        END,
-        to_timestamp(NEW.block_time) at time zone 'UTC'
-    FROM (
-        VALUES
-            ('send_ten'::verification_type),
-            ('send_one_hundred'::verification_type)
-    ) v(type)
-    WHERE NOT EXISTS (
-        SELECT 1
-        FROM distribution_verifications dv
-        WHERE dv.user_id = score_record.user_id
-            AND dv.distribution_id = score_record.distribution_id
-            AND dv.type = v.type
-    );
-
-    RETURN NEW;
-END;
-$function$
-;
-
-ALTER FUNCTION "public"."insert_verification_sends"() OWNER TO "postgres";
-
-GRANT ALL ON FUNCTION "public"."insert_verification_sends"() TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_verification_sends"() TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_verification_sends"() TO "service_role";
-
-
-CREATE OR REPLACE FUNCTION public.insert_verification_send_ceiling()
- RETURNS trigger
- LANGUAGE plpgsql
- SECURITY DEFINER
- SET search_path TO 'public'
-AS $function$
-DECLARE
-    score_record RECORD;
-BEGIN
-    -- Exit early if value is not positive
-    IF NOT (NEW.v > 0) THEN
-        RETURN NEW;
-    END IF;
-
-    -- Get send_scores_current result once
-    SELECT ss.distribution_id, ss.user_id, ss.score, ss.send_ceiling
-    INTO score_record
-    FROM send_scores_current ss
-    JOIN send_accounts sa ON sa.user_id = ss.user_id
-    WHERE sa.address = concat('0x', encode(NEW.f, 'hex'))::citext;
-
-    -- Early exit if no score found
-    IF NOT FOUND THEN
-        RETURN NEW;
-    END IF;
-
-    -- Try to update existing verification
-    UPDATE distribution_verifications dv
-    SET weight = score_record.score,
-        metadata = jsonb_build_object('value', score_record.send_ceiling::text)
-    WHERE dv.user_id = score_record.user_id
-        AND dv.distribution_id = score_record.distribution_id
-        AND dv.type = 'send_ceiling';
-
-    -- If no row was updated, insert new verification
-    IF NOT FOUND THEN
-        INSERT INTO distribution_verifications(
-            distribution_id,
-            user_id,
-            type,
-            weight,
-            metadata
-        )
-        VALUES (
-            score_record.distribution_id,
-            score_record.user_id,
-            'send_ceiling',
-            score_record.score,
-            jsonb_build_object('value', score_record.send_ceiling::text)
-        );
-    END IF;
-
-    RETURN NEW;
-EXCEPTION
-    WHEN OTHERS THEN
-        RAISE NOTICE 'Error in insert_verification_send_ceiling: %', SQLERRM;
-        RETURN NEW;
-END;
-$function$
-;
-
-ALTER FUNCTION "public"."insert_verification_send_ceiling"() OWNER TO "postgres";
+REVOKE ALL ON FUNCTION "public"."insert_verification_sends"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."insert_verification_sends"() FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_verification_sends"() TO service_role;
 
 REVOKE ALL ON FUNCTION "public"."insert_verification_send_ceiling"() FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."insert_verification_send_ceiling"() TO "anon";
-GRANT ALL ON FUNCTION "public"."insert_verification_send_ceiling"() TO "authenticated";
-GRANT ALL ON FUNCTION "public"."insert_verification_send_ceiling"() TO "service_role";
+REVOKE ALL ON FUNCTION "public"."insert_verification_send_ceiling"() FROM authenticated;
+GRANT ALL ON FUNCTION "public"."insert_verification_send_ceiling"() TO service_role;
 
-CREATE OR REPLACE FUNCTION refresh_send_scores_history()
-RETURNS void AS $$
-BEGIN
-  REFRESH MATERIALIZED VIEW CONCURRENTLY send_scores_history;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-
-ALTER FUNCTION "public"."refresh_send_scores_history"() OWNER TO "postgres";
-
-REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history"() FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."refresh_send_scores_history"() TO "anon";
-GRANT ALL ON FUNCTION "public"."refresh_send_scores_history"() TO "authenticated";
-GRANT ALL ON FUNCTION "public"."refresh_send_scores_history"() TO "service_role";
-
--- Trigger function
-CREATE OR REPLACE FUNCTION public.refresh_send_scores_history_trigger()
- RETURNS trigger
- LANGUAGE plpgsql
-AS $function$
-BEGIN
-  PERFORM refresh_send_scores_history();
-  RETURN NEW;
-END;
-$function$
-;
-
-ALTER FUNCTION "public"."refresh_send_scores_history_trigger"() OWNER TO "postgres";
-
-REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() FROM PUBLIC;
-GRANT ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() TO "anon";
-GRANT ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() TO "authenticated";
-GRANT ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() TO "service_role";
-
--- Trigger
-CREATE TRIGGER distribution_ended_refresh_send_scores
-  AFTER INSERT ON distributions
-  FOR EACH ROW
-  EXECUTE FUNCTION refresh_send_scores_history_trigger();
+REVOKE ALL ON FUNCTION "public"."insert_verification_send_ceiling"() FROM PUBLIC;
+GRANT ALL ON FUNCTION "public"."insert_verification_send_ceiling"() TO service_role;

--- a/supabase/schemas/send_earn.sql
+++ b/supabase/schemas/send_earn.sql
@@ -548,7 +548,7 @@ CREATE OR REPLACE VIEW "public"."send_earn_balances" WITH ("security_invoker"='o
 
 ALTER TABLE "public"."send_earn_balances" OWNER TO "postgres";
 
-CREATE OR REPLACE VIEW send_earn_balances_timeline AS
+CREATE OR REPLACE VIEW "public"."send_earn_balances_timeline" WITH ("security_invoker"='on', "security_barrier"='on') AS
 WITH all_transactions AS (
     SELECT owner, block_time, assets as balance
     FROM send_earn_deposit
@@ -607,6 +607,7 @@ ALTER TABLE "public"."send_earn_deposit" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."send_earn_new_affiliate" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "public"."send_earn_withdraw" ENABLE ROW LEVEL SECURITY;
 
+
 -- Policies
 CREATE POLICY "send_earn_create viewable by authenticated users" ON "public"."send_earn_create" FOR SELECT TO "authenticated" USING (true);
 CREATE POLICY "send_earn_new_affiliate viewable by authenticated users" ON "public"."send_earn_new_affiliate" FOR SELECT TO "authenticated" USING (true);
@@ -661,3 +662,8 @@ GRANT ALL ON SEQUENCE "public"."send_earn_new_affiliate_id_seq" TO "service_role
 GRANT ALL ON SEQUENCE "public"."send_earn_withdraw_id_seq" TO "anon";
 GRANT ALL ON SEQUENCE "public"."send_earn_withdraw_id_seq" TO "authenticated";
 GRANT ALL ON SEQUENCE "public"."send_earn_withdraw_id_seq" TO "service_role";
+
+REVOKE ALL ON "public"."send_earn_balances_timeline" FROM PUBLIC;
+REVOKE ALL ON "public"."send_earn_balances_timeline" FROM anon;
+GRANT ALL ON "public"."send_earn_balances_timeline" TO authenticated;
+GRANT ALL ON "public"."send_earn_balances_timeline" TO service_role;

--- a/supabase/schemas/send_scores.sql
+++ b/supabase/schemas/send_scores.sql
@@ -1,0 +1,188 @@
+CREATE OR REPLACE FUNCTION private.get_send_score(addr bytea)
+ RETURNS TABLE(distribution_id integer, score numeric, unique_sends bigint, send_ceiling numeric)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+BEGIN
+    RETURN QUERY
+    WITH active_distribution AS (
+        SELECT
+            d.id,
+            d.number,
+            EXTRACT(epoch FROM d.qualification_start) AS start_time,
+            EXTRACT(epoch FROM d.qualification_end) AS end_time,
+            d.hodler_min_balance,
+            d.earn_min_balance,
+            d.token_addr,
+            ss.minimum_sends,
+            ss.scaling_divisor,
+            (SELECT distributions.id FROM distributions WHERE distributions.number = (d.number - 1)) AS prev_distribution_id
+        FROM distributions d
+        JOIN send_slash ss ON ss.distribution_id = d.id
+        WHERE now() AT TIME ZONE 'UTC' >= d.qualification_start
+        AND now() AT TIME ZONE 'UTC' < d.qualification_end
+        LIMIT 1
+    ),
+    send_ceiling AS (
+        SELECT
+            ad.id AS distribution_id,
+            ROUND((
+                COALESCE(
+                    (SELECT
+                        CASE
+                            WHEN d.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea
+                            THEN ds.amount * '10000000000000000'::numeric
+                            ELSE ds.amount
+                        END
+                    FROM distribution_shares ds
+                    JOIN distributions d ON d.id = ds.distribution_id
+                    JOIN send_accounts sa ON sa.user_id = ds.user_id
+                    WHERE ds.distribution_id = ad.prev_distribution_id
+                    AND sa.address = concat('0x', encode(addr, 'hex'))::citext),
+                    CASE
+                        WHEN ad.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea
+                        THEN ad.hodler_min_balance * '10000000000000000'::numeric
+                        ELSE ad.hodler_min_balance
+                    END
+                ) / (ad.minimum_sends * ad.scaling_divisor)
+            ))::numeric AS send_ceiling,
+            ad.earn_min_balance,
+            ad.start_time,
+            ad.end_time
+        FROM active_distribution ad
+    ),
+    earn_balances_timeline AS (
+        SELECT owner,
+            block_time,
+            sum(balance) OVER w AS balance,
+            lead(block_time) OVER w AS next_block_time
+        FROM (
+            SELECT owner, block_time, assets AS balance
+            FROM send_earn_deposit
+            UNION ALL
+            SELECT owner, block_time, -assets
+            FROM send_earn_withdraw
+        ) earn_data
+        WINDOW w AS (PARTITION BY owner ORDER BY block_time ROWS UNBOUNDED PRECEDING)
+    )
+    SELECT
+        sc.distribution_id,
+        SUM(LEAST(transfer_sums.amount, sc.send_ceiling)) as score,
+        COUNT(DISTINCT transfer_sums.t) as unique_sends,
+        sc.send_ceiling
+    FROM send_ceiling sc
+    LEFT JOIN LATERAL (
+        SELECT t, SUM(v) as amount
+        FROM (
+            SELECT
+                stt.t,
+                stt.v,
+                stt.block_time
+            FROM send_token_transfers stt
+            WHERE stt.f = addr
+            AND stt.block_time >= sc.start_time
+            AND stt.block_time <= sc.end_time
+            UNION ALL
+            SELECT
+                stv.t,
+                stv.v * '10000000000000000'::numeric,
+                stv.block_time
+            FROM send_token_v0_transfers stv
+            WHERE stv.f = addr
+            AND stv.block_time >= sc.start_time
+            AND stv.block_time <= sc.end_time
+        ) transfers
+        WHERE sc.earn_min_balance = 0
+        OR EXISTS (
+            SELECT 1
+            FROM earn_balances_timeline ebt
+            WHERE ebt.owner = transfers.t
+            AND ebt.balance >= sc.earn_min_balance
+            AND ebt.block_time <= transfers.block_time
+            AND (ebt.next_block_time IS NULL OR transfers.block_time < ebt.next_block_time)
+        )
+        GROUP BY t
+    ) transfer_sums ON true
+    GROUP BY sc.distribution_id, sc.send_ceiling
+    HAVING SUM(LEAST(transfer_sums.amount, sc.send_ceiling)) > 0;
+END;
+$function$
+;
+
+ALTER FUNCTION "private"."get_send_score"(addr bytea) OWNER TO "postgres";
+
+CREATE OR REPLACE FUNCTION public.get_send_scores_history()
+ RETURNS TABLE(user_id uuid, distribution_id integer, score numeric, unique_sends bigint, send_ceiling numeric)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+
+BEGIN
+    IF auth.role() = 'authenticated' THEN
+        RETURN QUERY SELECT * FROM private.send_scores_history WHERE send_scores_history.user_id = (select auth.uid());
+    ELSE
+        RETURN QUERY SELECT * FROM private.send_scores_history;
+    END IF;
+END;
+$function$
+;
+
+ALTER FUNCTION "public"."get_send_scores_history"() OWNER TO "postgres";
+
+CREATE OR REPLACE FUNCTION public.refresh_send_scores_history()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY private.send_scores_history;
+END;
+$function$
+;
+
+ALTER FUNCTION "public"."refresh_send_scores_history"() OWNER TO "postgres";
+
+-- Trigger function
+CREATE OR REPLACE FUNCTION public.refresh_send_scores_history_trigger()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  PERFORM refresh_send_scores_history();
+  RETURN NEW;
+END;
+$function$
+;
+
+ALTER FUNCTION "public"."refresh_send_scores_history_trigger"() OWNER TO "postgres";
+
+-- Trigger
+CREATE TRIGGER distribution_ended_refresh_send_scores
+  AFTER INSERT ON distributions
+  FOR EACH ROW
+  EXECUTE FUNCTION refresh_send_scores_history_trigger();
+
+
+-- Revoke all public and authenticated access, grant only to service_role
+-- For all functions:
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() FROM authenticated;
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() FROM anon;
+GRANT ALL ON FUNCTION "public"."refresh_send_scores_history_trigger"() TO service_role;
+
+
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history"() FROM authenticated;
+REVOKE ALL ON FUNCTION "public"."refresh_send_scores_history"() FROM anon;
+GRANT ALL ON FUNCTION "public"."refresh_send_scores_history"() TO service_role;
+
+
+REVOKE ALL ON FUNCTION "public"."get_send_scores_history"() FROM PUBLIC;
+REVOKE ALL ON FUNCTION "public"."get_send_scores_history"() FROM anon;
+GRANT ALL ON FUNCTION "public"."get_send_scores_history"() TO authenticated;
+GRANT ALL ON FUNCTION "public"."get_send_scores_history"() TO service_role;
+
+REVOKE ALL ON FUNCTION "private"."get_send_score"(addr bytea) FROM PUBLIC;
+GRANT ALL ON FUNCTION "private"."get_send_score"(addr bytea) TO service_role;

--- a/supabase/schemas/views/send_scores.sql
+++ b/supabase/schemas/views/send_scores.sql
@@ -95,10 +95,8 @@ WHERE LEAST(
 ) > 0
 GROUP BY from_user_id, to_user_id;
 
-ALTER VIEW send_scores_current_unique OWNER TO postgres;
-
 -- Historical materialized view
-create materialized view "public"."send_scores_history" as  WITH distributions_with_score AS (
+create materialized view "private"."send_scores_history" as  WITH distributions_with_score AS (
          SELECT d.id,
             d.number,
             EXTRACT(epoch FROM d.qualification_start) AS start_time,
@@ -165,7 +163,7 @@ create materialized view "public"."send_scores_history" as  WITH distributions_w
                    FROM send_token_v0_transfers
                   WHERE ((send_token_v0_transfers.block_time >= bounds.min_start) AND (send_token_v0_transfers.block_time <= bounds.max_end))) transfers,
             distributions_with_score dws
-          WHERE (((transfers.block_time >= dws.start_time) AND (transfers.block_time <= dws.end_time)) AND ((dws.earn_min_balance = 0) OR (EXISTS ( SELECT 1
+          WHERE ((transfers.block_time >= dws.start_time) AND (transfers.block_time <= dws.end_time) AND ((dws.earn_min_balance = 0) OR (EXISTS ( SELECT 1
                    FROM earn_balances eb
                   WHERE ((eb.owner = transfers.t) AND (eb.block_time <= eb.block_time) AND ((eb.next_block_time IS NULL) OR (eb.block_time < eb.next_block_time)) AND (COALESCE(eb.balance, (0)::numeric) >= (dws.earn_min_balance)::numeric))))))
         )
@@ -190,15 +188,10 @@ create materialized view "public"."send_scores_history" as  WITH distributions_w
          HAVING (sum(LEAST(grouped_transfers.transfer_sum, grouped_transfers.send_ceiling)) > (0)::numeric)) scores
      JOIN send_ceiling_settings scs ON (((scores.address = scs.address) AND (scores.distribution_id = scs.distribution_id))));
 
-CREATE UNIQUE INDEX ON send_scores_history (user_id, distribution_id);
-
-ALTER MATERIALIZED VIEW send_scores_history OWNER TO postgres;
-
--- Add permissions for the materialized view
-GRANT ALL ON send_scores_history TO service_role;
-
 -- Current scores view
-create or replace view "public"."send_scores_current" as  WITH distributions_with_score AS (
+create or replace view "public"."send_scores_current" as  WITH authorized_user AS (
+         SELECT auth.uid() AS user_id
+        ), distributions_with_score AS (
          SELECT d.id,
             d.number,
             EXTRACT(epoch FROM d.qualification_start) AS start_time,
@@ -228,68 +221,69 @@ create or replace view "public"."send_scores_current" as  WITH distributions_wit
             dws.start_time,
             dws.end_time
            FROM distributions_with_score dws
-        ), adjusted_amounts AS (
+        ), authorized_accounts AS (
+         SELECT sa.user_id,
+            decode(replace((sa.address)::text, ('0x'::citext)::text, ''::text), 'hex'::text) AS address_bytes
+           FROM (send_accounts sa
+             CROSS JOIN authorized_user au)
+          WHERE ((au.user_id IS NULL) OR (sa.user_id = au.user_id))
+        ), authorized_distribution_shares AS (
          SELECT ds.user_id,
                 CASE
                     WHEN (d.token_addr = '\x3f14920c99beb920afa163031c4e47a3e03b3e4a'::bytea) THEN (ds.amount * '10000000000000000'::numeric)
                     ELSE ds.amount
                 END AS adjusted_amount
-           FROM ((base_ceiling bc
+           FROM (((base_ceiling bc
              JOIN distribution_shares ds ON ((ds.distribution_id = bc.prev_distribution_id)))
              JOIN distributions d ON ((d.id = ds.distribution_id)))
+             JOIN authorized_accounts aa ON ((aa.user_id = ds.user_id)))
         ), send_ceiling_settings AS (
-         SELECT sa.user_id,
-            decode(replace(sa.address, '0x'::citext, ''::citext), 'hex'::text) AS address,
+         SELECT aa.user_id,
+            aa.address_bytes AS address,
             bc.distribution_id,
-            round((COALESCE(aa.adjusted_amount, bc.base_amount) / ((bc.minimum_sends * bc.scaling_divisor))::numeric)) AS send_ceiling
+            round((COALESCE(ads.adjusted_amount, bc.base_amount) / ((bc.minimum_sends * bc.scaling_divisor))::numeric)) AS send_ceiling
            FROM ((base_ceiling bc
-             CROSS JOIN send_accounts sa)
-             LEFT JOIN adjusted_amounts aa ON ((aa.user_id = sa.user_id)))
-        ), earn_balance_data AS (
-         SELECT send_earn_deposit.owner,
-            send_earn_deposit.block_time,
-            send_earn_deposit.assets AS balance
-           FROM send_earn_deposit
-        UNION ALL
-         SELECT send_earn_withdraw.owner,
-            send_earn_withdraw.block_time,
-            (- send_earn_withdraw.assets) AS balance
-           FROM send_earn_withdraw
-        ), earn_balances AS (
-         SELECT sub.owner,
-            sub.block_time,
-            sub.balance,
-            sub.next_block_time
-           FROM ( SELECT earn_balance_data.owner,
-                    earn_balance_data.block_time,
-                    sum(earn_balance_data.balance) OVER w AS balance,
-                    lead(earn_balance_data.block_time) OVER w AS next_block_time
-                   FROM earn_balance_data
-                  WINDOW w AS (PARTITION BY earn_balance_data.owner ORDER BY earn_balance_data.block_time ROWS UNBOUNDED PRECEDING)) sub
-          WHERE (sub.balance >= (( SELECT base_ceiling.earn_min_balance
-                   FROM base_ceiling))::numeric)
+             CROSS JOIN authorized_accounts aa)
+             LEFT JOIN authorized_distribution_shares ads ON ((ads.user_id = aa.user_id)))
+        ), earn_balances_timeline AS (
+         SELECT earn_data.owner,
+            earn_data.block_time,
+            sum(earn_data.balance) OVER w AS balance,
+            lead(earn_data.block_time) OVER w AS next_block_time
+           FROM ( SELECT send_earn_deposit.owner,
+                    send_earn_deposit.block_time,
+                    send_earn_deposit.assets AS balance
+                   FROM send_earn_deposit
+                UNION ALL
+                 SELECT send_earn_withdraw.owner,
+                    send_earn_withdraw.block_time,
+                    (- send_earn_withdraw.assets)
+                   FROM send_earn_withdraw) earn_data
+          WINDOW w AS (PARTITION BY earn_data.owner ORDER BY earn_data.block_time ROWS UNBOUNDED PRECEDING)
         ), transfer_sums AS (
          SELECT transfers.f,
             bc.distribution_id,
             transfers.t,
             sum(transfers.v) AS transfer_sum
            FROM (base_ceiling bc
-             CROSS JOIN LATERAL ( SELECT send_token_transfers.f,
-                    send_token_transfers.t,
-                    send_token_transfers.v,
-                    send_token_transfers.block_time
-                   FROM send_token_transfers
-                  WHERE ((send_token_transfers.block_time >= bc.start_time) AND (send_token_transfers.block_time <= bc.end_time))
+             CROSS JOIN LATERAL ( SELECT stt.f,
+                    stt.t,
+                    stt.v,
+                    stt.block_time
+                   FROM send_token_transfers stt
+                  WHERE ((stt.block_time >= bc.start_time) AND (stt.block_time <= bc.end_time) AND (stt.f IN ( SELECT authorized_accounts.address_bytes
+                           FROM authorized_accounts)))
                 UNION ALL
-                 SELECT send_token_v0_transfers.f,
-                    send_token_v0_transfers.t,
-                    (send_token_v0_transfers.v * '10000000000000000'::numeric),
-                    send_token_v0_transfers.block_time
-                   FROM send_token_v0_transfers
-                  WHERE ((send_token_v0_transfers.block_time >= bc.start_time) AND (send_token_v0_transfers.block_time <= bc.end_time))) transfers)
+                 SELECT stv.f,
+                    stv.t,
+                    (stv.v * '10000000000000000'::numeric),
+                    stv.block_time
+                   FROM send_token_v0_transfers stv
+                  WHERE ((stv.block_time >= bc.start_time) AND (stv.block_time <= bc.end_time) AND (stv.f IN ( SELECT authorized_accounts.address_bytes
+                           FROM authorized_accounts)))) transfers)
           WHERE ((bc.earn_min_balance = 0) OR (EXISTS ( SELECT 1
-                   FROM earn_balances eb
-                  WHERE ((eb.owner = transfers.t) AND (eb.block_time <= transfers.block_time) AND ((eb.next_block_time IS NULL) OR (transfers.block_time < eb.next_block_time))))))
+                   FROM earn_balances_timeline ebt
+                  WHERE ((ebt.owner = transfers.t) AND (ebt.balance >= (bc.earn_min_balance)::numeric) AND (ebt.block_time <= transfers.block_time) AND ((ebt.next_block_time IS NULL) OR (transfers.block_time < ebt.next_block_time))))))
           GROUP BY transfers.f, bc.distribution_id, transfers.t
         )
  SELECT scs.user_id,
@@ -307,14 +301,12 @@ create or replace view "public"."send_scores_current" as  WITH distributions_wit
          HAVING (sum(LEAST(ts.transfer_sum, scs_1.send_ceiling)) > (0)::numeric)) scores
      JOIN send_ceiling_settings scs ON (((scores.address = scs.address) AND (scores.distribution_id = scs.distribution_id))));
 
-ALTER VIEW send_scores_current OWNER TO postgres;
-
-create or replace view "public"."send_scores" as  SELECT send_scores_history.user_id,
-    send_scores_history.distribution_id,
-    send_scores_history.score,
-    send_scores_history.unique_sends,
-    send_scores_history.send_ceiling
-   FROM send_scores_history
+create or replace view "public"."send_scores" as  SELECT get_send_scores_history.user_id,
+    get_send_scores_history.distribution_id,
+    get_send_scores_history.score,
+    get_send_scores_history.unique_sends,
+    get_send_scores_history.send_ceiling
+   FROM get_send_scores_history() get_send_scores_history(user_id, distribution_id, score, unique_sends, send_ceiling)
 UNION ALL
  SELECT send_scores_current.user_id,
     send_scores_current.distribution_id,
@@ -323,4 +315,30 @@ UNION ALL
     send_scores_current.send_ceiling
    FROM send_scores_current;
 
-ALTER VIEW send_scores OWNER TO postgres;
+
+-- Indexes
+CREATE UNIQUE INDEX send_scores_history_user_id_distribution_id_idx ON private.send_scores_history USING btree (user_id, distribution_id);
+
+
+-- Owners
+ALTER MATERIALIZED VIEW "private"."send_scores_history" OWNER TO postgres;
+ALTER VIEW "public"."send_scores_current_unique" OWNER TO postgres;
+ALTER VIEW "public"."send_scores_current" OWNER TO postgres;
+ALTER VIEW "public"."send_scores" OWNER TO postgres;
+
+-- Permissions
+REVOKE ALL ON "private"."send_scores_history" FROM PUBLIC;
+REVOKE ALL ON "private"."send_scores_history" FROM authenticated;
+GRANT ALL ON "private"."send_scores_history" TO service_role;
+
+REVOKE ALL ON "public"."send_scores_current_unique" FROM PUBLIC;
+GRANT ALL ON "public"."send_scores_current_unique" TO service_role;
+GRANT ALL ON "public"."send_scores_current_unique" TO authenticated;
+
+REVOKE ALL ON "public"."send_scores_current" FROM PUBLIC;
+GRANT ALL ON "public"."send_scores_current" TO service_role;
+GRANT ALL ON "public"."send_scores_current" TO authenticated;
+
+REVOKE ALL ON "public"."send_scores" FROM PUBLIC;
+GRANT ALL ON "public"."send_scores" TO service_role;
+GRANT ALL ON "public"."send_scores" TO authenticated;

--- a/supabase/tests/distribution_hodler_addresses_test.sql
+++ b/supabase/tests/distribution_hodler_addresses_test.sql
@@ -13,6 +13,33 @@ SELECT
             * FROM distribution_hodler_addresses(999999) $$, 'Distribution not found.', 'Should raise exception if distribution does not exist');
 SELECT
     tests.create_supabase_user('hodler');
+
+INSERT INTO send_account_created(
+    chain_id,
+    log_addr,
+    block_time,
+    tx_hash,
+    account,
+    ig_name,
+    src_name,
+    block_num,
+    tx_idx,
+    log_idx
+) VALUES
+-- For the hodler
+(
+    8453,
+    decode(:hodler_address, 'hex'),
+    extract(epoch FROM '2023-01-01 00:00:00.000000 +00:00'::timestamp),
+    '\x1234'::bytea,
+    decode(:hodler_address, 'hex'),
+    'send_account_created',
+    'send_account_created',
+    18180000,
+    1,
+    1
+);
+
 -- create a liquidity pool
 INSERT INTO send_liquidity_pools(
     address,
@@ -196,4 +223,3 @@ SELECT
 SELECT
     finish();
 ROLLBACK;
-


### PR DESCRIPTION
### TL;DR

Improved security and performance of Send Scores functionality by moving the materialized view to the private schema and implementing a secure access pattern.

### What changed?

- Moved `send_scores_history` from public to private schema to improve security
- Created a new `get_send_scores_history()` function with proper security definer settings
- Added a new `get_send_score()` function in the private schema to calculate scores efficiently
- Updated the `send_scores` view to use the new function-based approach
- Refactored verification triggers to use the private function instead of querying views
- Added proper permission controls to all related functions and views
- Added a new schema file `send_scores.sql` to organize the Send Scores functionality

### How to test?

1. Run the migration to apply the changes
2. Verify that authenticated users can still access their own Send Scores data
3. Confirm that the `send_scores` view returns the same data as before
4. Test that the verification triggers still work correctly when transfers occur
5. Verify that the materialized view refreshes correctly when distributions end

### Why make this change?

The previous implementation exposed the entire Send Scores history to all authenticated users and used inefficient view-based calculations. This change:

1. Improves security by restricting access to only a user's own data
2. Enhances performance by using a more efficient function-based approach
3. Reduces database load by optimizing the calculation logic
4. Follows security best practices by using security definer functions
5. Provides better organization of the Send Scores functionality