### PR TITLE
Native: share profile qr code

### DIFF
--- a/apps/next/next.config.js
+++ b/apps/next/next.config.js
@@ -141,6 +141,7 @@ export default () => {
       '@ts-react/form',
       'react-hook-form',
       'react-native-passkeys',
+      'react-native-qrcode-svg',
     ],
     experimental: {
       optimizePackageImports: [

--- a/packages/app/features/account/components/ShareProfileDialog.tsx
+++ b/packages/app/features/account/components/ShareProfileDialog.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   Dialog,
   H2,
-  Image,
   isWeb,
   Paragraph,
   Separator,
@@ -14,9 +13,8 @@ import { IconCopy } from 'app/components/icons'
 import { useConfirmedTags } from 'app/utils/tags'
 import { useUser } from 'app/utils/useUser'
 import * as Clipboard from 'expo-clipboard'
-import QRCode from 'qrcode'
-import { useEffect, useState } from 'react'
 import { Platform } from 'react-native'
+import QRCodeSVG from 'react-native-qrcode-svg'
 
 interface ShareProfileDialogProps {
   isOpen: boolean
@@ -27,7 +25,6 @@ export function ShareProfileDialog({ isOpen, onClose }: ShareProfileDialogProps)
   const { profile } = useUser()
   const tags = useConfirmedTags()
   const toast = useToastController()
-  const [qrCodeDataURL, setQrCodeDataURL] = useState<string>('')
 
   // Use sendtag if available, otherwise fall back to send_id
   const sendtag = tags?.[0]?.name
@@ -35,30 +32,6 @@ export function ShareProfileDialog({ isOpen, onClose }: ShareProfileDialogProps)
   const profileUrl = sendtag
     ? `https://${hostname}/${sendtag}`
     : `https://${hostname}/profile/${profile?.send_id}`
-
-  useEffect(() => {
-    if (isOpen && profileUrl) {
-      QRCode.toDataURL(profileUrl, {
-        width: 200,
-        margin: 2,
-        color: {
-          dark: '#000000',
-          light: '#FFFFFF',
-        },
-      })
-        .then(setQrCodeDataURL)
-        .catch((e) => {
-          console.error(e)
-          toast.show('Failed to create QR code', {
-            message: 'Something went wrong while creating QR code',
-            customData: {
-              theme: 'red',
-            },
-          })
-          setQrCodeDataURL('')
-        })
-    }
-  }, [isOpen, profileUrl, toast.show])
 
   const handleCopyLink = async () => {
     try {
@@ -81,9 +54,9 @@ export function ShareProfileDialog({ isOpen, onClose }: ShareProfileDialogProps)
         Share Profile
       </H2>
       <Separator boc={'$silverChalice'} $theme-light={{ boc: '$darkGrayTextField' }} />
-      {qrCodeDataURL && (
+      {profileUrl && (
         <YStack ai={'center'} gap={'$3'}>
-          <Image source={{ uri: qrCodeDataURL }} width={200} height={200} br={'$3'} />
+          <QRCodeSVG value={profileUrl} size={200} color="#000000" backgroundColor="#FFFFFF" />
           <Paragraph size={'$4'} color={'$color10'} ta={'center'} numberOfLines={1}>
             {profileUrl}
           </Paragraph>
@@ -159,7 +132,7 @@ export function ShareProfileDialog({ isOpen, onClose }: ShareProfileDialogProps)
       dismissOnSnapToBottom
       dismissOnOverlayPress
       native
-      snapPoints={[70]}
+      snapPoints={[65]}
     >
       <Sheet.Frame key="share-profile-sheet" gap="$3.5" padding="$5">
         {dialogContent}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -60,6 +60,7 @@
     "react-hook-form": "^7.48.2",
     "react-native": "0.76.9",
     "react-native-passkeys": "~0.3.3",
+    "react-native-qrcode-svg": "^6.3.2",
     "react-native-svg": "15.10.1",
     "react-native-webview": "13.12.5",
     "react-use-precision-timer": "^3.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13621,6 +13621,7 @@ __metadata:
     react-hook-form: "npm:^7.48.2"
     react-native: "npm:0.76.9"
     react-native-passkeys: "npm:~0.3.3"
+    react-native-qrcode-svg: "npm:^6.3.2"
     react-native-svg: "npm:15.10.1"
     react-native-webview: "npm:13.12.5"
     react-test-renderer: "npm:^18.3.1"
@@ -28747,7 +28748,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:15.8.1, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:15.8.1, prop-types@npm:^15.7.2, prop-types@npm:^15.8.0, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -29399,6 +29400,21 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10/428f50f36efcedf0bcd9aa762921e4bd502ae834b7ff023c9e36a7da7ec6e823efe84796173d50c62880a8aacabb9549339c9974a80e439ecac8339b19eeac48
+  languageName: node
+  linkType: hard
+
+"react-native-qrcode-svg@npm:^6.3.2":
+  version: 6.3.15
+  resolution: "react-native-qrcode-svg@npm:6.3.15"
+  dependencies:
+    prop-types: "npm:^15.8.0"
+    qrcode: "npm:^1.5.4"
+    text-encoding: "npm:^0.7.0"
+  peerDependencies:
+    react: "*"
+    react-native: ">=0.63.4"
+    react-native-svg: ">=14.0.0"
+  checksum: 10/5b3e3a346732bc6acdd218ed4b5a3f7be8b675a00732496186ab22e553d31a48721d5a12f46838daa9d4279b23d20e438379bfdfdc1ded201570951895d90741
   languageName: node
   linkType: hard
 
@@ -32840,6 +32856,13 @@ __metadata:
     glob: "npm:^7.1.4"
     minimatch: "npm:^3.0.4"
   checksum: 10/8fccb2cb6c8fcb6bb4115394feb833f8b6cf4b9503ec2485c2c90febf435cac62abe882a0c5c51a37b9bbe70640cdd05acf5f45e486ac4583389f4b0855f69e5
+  languageName: node
+  linkType: hard
+
+"text-encoding@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "text-encoding@npm:0.7.0"
+  checksum: 10/c61b7a59a54c58f0714da0ef4c1f65732821bb1f761e6f21c3e681e51c6dd56fdefa4fcfccd3254bf47132d87420fbc9898da21a804c89e87861f4e1478d5f18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary 

The PR introduces changes to share a user's profile QR code, replacing the `qrcode` library with `react-native-qrcode-svg` and updating the `ShareProfileDialog` component.


## Changes Made

- Replaced `qrcode` library with `react-native-qrcode-svg`
- Updated `ShareProfileDialog` component to use `QRCodeSVG`
- Removed `useEffect` hook for generating QR code
- Added `react-native-qrcode-svg` to dependencies

_written by Kolwaii, your beloved blockchain engineer AI agent_