### PR TITLE
Added send id to get friends

### DIFF
--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -1807,6 +1807,7 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: {
           avatar_url: string
+          send_id: number
           x_username: string
           birthday: string
           tag: string

--- a/supabase/migrations/20250716111120_add_send_id_to_get_friends.sql
+++ b/supabase/migrations/20250716111120_add_send_id_to_get_friends.sql
@@ -1,0 +1,55 @@
+drop function if exists "public"."get_friends"();
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_friends()
+ RETURNS TABLE(avatar_url text, send_id integer, x_username text, birthday date, tag citext, created_at timestamp with time zone)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+    RETURN QUERY
+        WITH ordered_referrals AS(
+            SELECT
+                DISTINCT ON (r.referred_id)
+                p.avatar_url,
+                p.send_id,
+                CASE WHEN p.is_public THEN p.x_username ELSE NULL END AS x_username,
+                CASE WHEN p.is_public THEN p.birthday ELSE NULL END AS birthday,
+                t.name AS tag,
+                t.created_at,
+                COALESCE((
+                             SELECT
+                                 SUM(amount)
+                             FROM distribution_shares ds
+                             WHERE
+                                 ds.user_id = r.referred_id
+                               AND distribution_id >= 6), 0) AS send_score
+            FROM
+                referrals r
+                    LEFT JOIN affiliate_stats a ON a.user_id = r.referred_id
+                    LEFT JOIN profiles p ON p.id = r.referred_id
+                    LEFT JOIN tags t ON t.user_id = r.referred_id
+            WHERE
+                r.referrer_id = (SELECT auth.uid())
+                AND t.status = 'confirmed'::tag_status
+            ORDER BY
+                r.referred_id,
+                t.created_at DESC)
+        SELECT
+            o.avatar_url,
+            o.send_id,
+            o.x_username,
+            o.birthday,
+            o.tag,
+            o.created_at
+        FROM
+            ordered_referrals o
+        ORDER BY
+            send_score DESC;
+END;
+$function$
+;
+
+

--- a/supabase/schemas/referrals.sql
+++ b/supabase/schemas/referrals.sql
@@ -390,7 +390,7 @@ GRANT ALL ON FUNCTION "public"."profile_lookup"("lookup_type" "public"."lookup_t
 -- Functions
 
 CREATE OR REPLACE FUNCTION public.get_friends()
- RETURNS TABLE(avatar_url text, x_username text, birthday date, tag citext, created_at timestamp with time zone)
+ RETURNS TABLE(avatar_url text, send_id int, x_username text, birthday date, tag citext, created_at timestamp with time zone)
  LANGUAGE plpgsql
  SECURITY DEFINER
  SET search_path TO 'public'
@@ -401,6 +401,7 @@ BEGIN
             SELECT
                 DISTINCT ON (r.referred_id)
                 p.avatar_url,
+                p.send_id,
                 CASE WHEN p.is_public THEN p.x_username ELSE NULL END AS x_username,
                 CASE WHEN p.is_public THEN p.birthday ELSE NULL END AS birthday,
                 t.name AS tag,
@@ -425,6 +426,7 @@ BEGIN
                 t.created_at DESC)
         SELECT
             o.avatar_url,
+            o.send_id,
             o.x_username,
             o.birthday,
             o.tag,


### PR DESCRIPTION
## Summary 

Added `send_id` to the `get_friends` function in the Supabase database.


## Changes Made

- Added `send_id` to the `get_friends` function return type
- Updated the `get_friends` function to include `send_id` in the query results
- Modified the `get_friends` function to return `send_id` as an integer

_written by Kolwaii, your beloved blockchain engineer AI agent_