### PR TITLE
Removed supabase from query keys

### DIFF
--- a/packages/app/features/account/sendtag/checkout/checkout-utils.ts
+++ b/packages/app/features/account/sendtag/checkout/checkout-utils.ts
@@ -39,8 +39,9 @@ export function useReferralReward({ tags }: { tags: { name: string }[] }) {
 
 function sendtagCheckoutReceiptsQueryOptions(supabase: SupabaseClient<Database>) {
   return queryOptions({
-    queryKey: ['sendtag_checkout_transfers', supabase] as const,
-    queryFn: async ({ queryKey: [, supabase] }) => {
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['sendtag_checkout_transfers'] as const,
+    queryFn: async () => {
       const { data, error } = await fetchSendtagCheckoutReceipts(supabase)
       throwIf(error)
       return data

--- a/packages/app/features/activity/utils/useActivityFeed.ts
+++ b/packages/app/features/activity/utils/useActivityFeed.ts
@@ -36,8 +36,8 @@ export function useActivityFeed({
   const addressBook = useAddressBook()
   const enabled = useMemo(() => addressBook.isError || addressBook.isSuccess, [addressBook])
   const queryKey = useMemo(
-    () => ['activity_feed', { addressBook, supabase, pageSize }] as const,
-    [addressBook, supabase, pageSize]
+    () => ['activity_feed', { addressBook, pageSize }] as const,
+    [addressBook, pageSize]
   )
   return useInfiniteQuery<
     Activity[],
@@ -47,6 +47,7 @@ export function useActivityFeed({
     number
   >({
     enabled,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey,
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
@@ -59,7 +60,7 @@ export function useActivityFeed({
       }
       return firstPageParam - 1
     },
-    queryFn: async ({ queryKey: [, { addressBook, supabase, pageSize }], pageParam }) => {
+    queryFn: async ({ queryKey: [, { addressBook, pageSize }], pageParam }) => {
       throwIf(addressBook.error)
       assert(!!addressBook.data, 'Fetching address book failed')
       return await fetchActivityFeed({

--- a/packages/app/features/earn/deposit/hooks/index.ts
+++ b/packages/app/features/earn/deposit/hooks/index.ts
@@ -27,9 +27,9 @@ export function useReferrerVault(): UseQueryReturnType<`0x${string}` | null> {
   const referredBy = useReferredBy()
 
   return useQuery({
-    queryKey: ['referrerVault', { supabase, referredBy, referrer }] as const,
+    queryKey: ['referrerVault', { referredBy, referrer }] as const,
     queryFn: async ({
-      queryKey: [, { supabase, referredBy, referrer }],
+      queryKey: [, { referredBy, referrer }],
       signal,
     }): Promise<`0x${string}` | null> => {
       throwIf(referredBy.isError)
@@ -71,7 +71,9 @@ export function useReferrerVault(): UseQueryReturnType<`0x${string}` | null> {
  */
 export function useSendEarnDepositVault({
   asset,
-}: { asset: `0x${string}` | undefined }): UseQueryReturnType<`0x${string}` | null> {
+}: {
+  asset: `0x${string}` | undefined
+}): UseQueryReturnType<`0x${string}` | null> {
   const referrerVault = useReferrerVault()
   const balances = useSendEarnBalances()
   const sendAccount = useSendAccount()
@@ -267,7 +269,9 @@ export function useSendEarnDepositCalls({
  */
 function useSendEarnFactory({
   asset,
-}: { asset: `0x${string}` | undefined }): UseQueryReturnType<`0x${string}`> {
+}: {
+  asset: `0x${string}` | undefined
+}): UseQueryReturnType<`0x${string}`> {
   const chainId = useChainId()
   return useQuery({
     enabled: asset !== undefined,

--- a/packages/app/features/earn/hooks/index.ts
+++ b/packages/app/features/earn/hooks/index.ts
@@ -172,7 +172,8 @@ async function fetchSendEarnBalances(supabase: SupabaseClient<Database>) {
  */
 export function sendEarnBalancesQueryOptions(supabase: SupabaseClient<Database>) {
   return queryOptions({
-    queryKey: ['send_earn_balances', { supabase }] as const,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['send_earn_balances'] as const,
     queryFn: async () => fetchSendEarnBalances(supabase),
     staleTime: 30_000,
   })
@@ -204,7 +205,8 @@ async function fetchSendEarnBalancesTimeline(supabase: SupabaseClient<Database>)
 
 export function sendEarnBalancesTimelineQueryOptions(supabase: SupabaseClient<Database>) {
   return queryOptions({
-    queryKey: ['send_earn_balances_timeline', { supabase }] as const,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['send_earn_balances_timeline'] as const,
     queryFn: async () => fetchSendEarnBalancesTimeline(supabase),
     staleTime: 30_000,
   })
@@ -248,7 +250,8 @@ export function sendEarnBalancesAtBlockQueryOptions(
   block_num: bigint | null
 ) {
   return queryOptions({
-    queryKey: ['send_earn_balances_at_block', { supabase, block_num }] as const,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['send_earn_balances_at_block', { block_num }] as const,
     queryFn: async () => fetchSendEarnBalancesAtBlock(supabase, block_num),
     staleTime: 30_000,
   })

--- a/packages/app/features/earn/rewards/hooks/index.ts
+++ b/packages/app/features/earn/rewards/hooks/index.ts
@@ -111,9 +111,9 @@ export function useEarnRewardsActivityFeed(params?: {
     () =>
       [
         'earn_rewards_activity_feed',
-        { addressBook, supabase, pageSize, sendAccount, sendAccountData, myAffiliateVault },
+        { addressBook, pageSize, sendAccount, sendAccountData, myAffiliateVault },
       ] as const,
-    [addressBook, supabase, pageSize, sendAccount, sendAccountData, myAffiliateVault]
+    [addressBook, pageSize, sendAccount, sendAccountData, myAffiliateVault]
   )
 
   return useInfiniteQuery<
@@ -124,6 +124,7 @@ export function useEarnRewardsActivityFeed(params?: {
     number
   >({
     enabled,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey,
     refetchInterval,
     initialPageParam: 0,
@@ -138,10 +139,7 @@ export function useEarnRewardsActivityFeed(params?: {
       return firstPageParam - 1
     },
     queryFn: async ({
-      queryKey: [
-        ,
-        { addressBook, supabase, pageSize, sendAccount, sendAccountData, myAffiliateVault },
-      ],
+      queryKey: [, { addressBook, pageSize, sendAccount, sendAccountData, myAffiliateVault }],
       pageParam,
     }) => {
       throwIf(addressBook.error)

--- a/packages/app/features/earn/utils/useEarnActivityFeed.ts
+++ b/packages/app/features/earn/utils/useEarnActivityFeed.ts
@@ -43,8 +43,8 @@ export function useEarnActivityFeed(params?: {
   )
 
   const queryKey = useMemo(
-    () => ['earn_activity_feed', { addressBook, supabase, pageSize, sendAccount }] as const,
-    [addressBook, supabase, pageSize, sendAccount]
+    () => ['earn_activity_feed', { addressBook, pageSize, sendAccount }] as const,
+    [addressBook, pageSize, sendAccount]
   )
 
   return useInfiniteQuery<
@@ -55,6 +55,7 @@ export function useEarnActivityFeed(params?: {
     number
   >({
     enabled,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey,
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
@@ -67,10 +68,7 @@ export function useEarnActivityFeed(params?: {
       }
       return firstPageParam - 1
     },
-    queryFn: async ({
-      queryKey: [, { addressBook, supabase, pageSize, sendAccount }],
-      pageParam,
-    }) => {
+    queryFn: async ({ queryKey: [, { addressBook, pageSize, sendAccount }], pageParam }) => {
       throwIf(addressBook.error)
       throwIf(sendAccount.error)
       assert(!!addressBook.data, 'Fetching address book failed')

--- a/packages/app/features/home/RewardsCard.tsx
+++ b/packages/app/features/home/RewardsCard.tsx
@@ -126,11 +126,12 @@ const useDistributionShares = () => {
   const { data: sendAccount } = useSendAccount()
 
   return useQuery({
-    queryKey: ['distribution_shares', supabase, sendAccount?.created_at],
+    queryKey: ['distribution_shares', sendAccount?.created_at],
     queryFn: async () => {
       const { data, error } = await supabase
         .from('distributions')
-        .select(`
+        .select(
+          `
           number,
           token_addr,
           chain_id,
@@ -141,7 +142,8 @@ const useDistributionShares = () => {
             amount::text,
             index::text
           )
-        `)
+        `
+        )
         .lte('qualification_start', new Date().toUTCString())
         .gt('qualification_end', sendAccount?.created_at)
         .not('distribution_shares[0]', 'is', null) // checks if first element exists

--- a/packages/app/features/home/utils/useTokenActivityFeed.ts
+++ b/packages/app/features/home/utils/useTokenActivityFeed.ts
@@ -34,8 +34,8 @@ export function useTokenActivityFeed(params: {
   const supabase = useSupabase()
   const enabled = useMemo(() => enabledProp, [enabledProp])
   const queryKey = useMemo(
-    () => ['token_activity_feed', { supabase, pageSize, address }] as const,
-    [supabase, pageSize, address]
+    () => ['token_activity_feed', { pageSize, address }] as const,
+    [pageSize, address]
   )
   return useInfiniteQuery<
     Activity[],
@@ -45,6 +45,7 @@ export function useTokenActivityFeed(params: {
     number
   >({
     enabled,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey,
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
@@ -57,7 +58,7 @@ export function useTokenActivityFeed(params: {
       }
       return firstPageParam - 1
     },
-    queryFn: async ({ queryKey: [, { supabase, pageSize, address }], pageParam }) => {
+    queryFn: async ({ queryKey: [, { pageSize, address }], pageParam }) => {
       return await fetchTokenActivityFeed({
         address,
         pageParam,

--- a/packages/app/utils/distributions.ts
+++ b/packages/app/utils/distributions.ts
@@ -106,7 +106,8 @@ function fetchDistributions(supabase: SupabaseClient<Database>) {
 export const useDistributions = (): UseQueryResult<UseDistributionsResultData, PostgrestError> => {
   const supabase = useSupabase()
   return useQuery({
-    queryKey: ['distributions', supabase],
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['distributions'],
     queryFn: async () => {
       const { data, error } = await fetchDistributions(supabase).order('number', {
         ascending: false,
@@ -138,7 +139,8 @@ export const useMonthlyDistributions = () => {
   const { data: sendAccount } = useSendAccount()
 
   return useQuery({
-    queryKey: ['monthly_distributions', supabase, sendAccount?.created_at],
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['monthly_distributions', sendAccount?.created_at],
     queryFn: async () => {
       const { data, error } = await fetchDistributions(supabase)
         .gt('number', 6)
@@ -204,8 +206,9 @@ export const useDistributionVerifications = (distributionNumber?: number) => {
   const supabase = useSupabase()
 
   return useQuery({
-    queryKey: ['distribution_verifications', { distributionNumber, supabase }] as const,
-    queryFn: async ({ queryKey: [, { distributionNumber, supabase }] }) => {
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['distribution_verifications', { distributionNumber }] as const,
+    queryFn: async ({ queryKey: [, { distributionNumber }] }) => {
       assert(!!distributionNumber, 'distributionNumber is required')
 
       const { data, error } = await fetchDistributionVerifications(supabase, distributionNumber)

--- a/packages/app/utils/referrer.ts
+++ b/packages/app/utils/referrer.ts
@@ -99,8 +99,9 @@ export function useReferrer() {
   const { profile } = useUser()
   const referralCode = useReferralCodeQuery()
   return useQuery({
-    queryKey: ['referrer', { referralCode, supabase, profile }] as const,
-    queryFn: async ({ queryKey: [, { referralCode, supabase, profile }], signal }) => {
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['referrer', { referralCode, profile }] as const,
+    queryFn: async ({ queryKey: [, { referralCode, profile }], signal }) => {
       throwIf(referralCode.error)
       assert(!!supabase, 'supabase is required')
       assert(!!profile, 'profile is required')
@@ -123,8 +124,9 @@ export function fetchReferredBy({ supabase }: { supabase: SupabaseClient<Databas
 export function useReferredBy() {
   const supabase = useSupabase()
   return useQuery({
-    queryKey: ['referredBy', { supabase }] as const,
-    queryFn: async ({ queryKey: [, { supabase }], signal }) => {
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['referredBy'] as const,
+    queryFn: async ({ signal }) => {
       assert(!!supabase, 'supabase is required')
       const { data, error } = await fetchReferredBy({ supabase }).abortSignal(signal).maybeSingle()
       if (error) {

--- a/packages/app/utils/useProfileLookup.ts
+++ b/packages/app/utils/useProfileLookup.ts
@@ -34,9 +34,10 @@ export function profileLookupQueryOptions({
   identifier: string | undefined
 }) {
   return queryOptions({
-    queryKey: ['profile', { lookup_type, identifier, supabase }] as const,
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['profile', { lookup_type, identifier }] as const,
     queryFn: async ({
-      queryKey: [, { supabase, lookup_type, identifier }],
+      queryKey: [, { lookup_type, identifier }],
     }): Promise<Functions<'profile_lookup'>[number] | null> => {
       assert(!!lookup_type, 'lookup_type is required')
       assert(!!identifier, 'identifier is required')

--- a/packages/app/utils/useReferrer.ts
+++ b/packages/app/utils/useReferrer.ts
@@ -56,8 +56,9 @@ export function useReferrer() {
   const { data: referralCode, isLoading } = useReferralCodeQuery()
 
   return useQuery({
-    queryKey: ['referrer', { referralCode, supabase, profile }] as const,
-    queryFn: async ({ queryKey: [, { referralCode, supabase, profile }], signal }) => {
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
+    queryKey: ['referrer', { referralCode, profile }] as const,
+    queryFn: async ({ queryKey: [, { referralCode, profile }], signal }) => {
       assert(!!supabase, 'supabase is required')
       assert(!!profile, 'profile is required')
       return fetchReferrer({


### PR DESCRIPTION
## Summary 

Main goal is to improve performance and reduce API calls by removing unnecessary supabase object from query keys

## Changes Made

- Removed supabase from query keys in sendtagCheckoutReceiptsQueryOptions
- Removed supabase from query keys in useActivityFeed
- Removed supabase from query keys in useReferrerVault
- Removed supabase from query keys in sendEarnBalancesQueryOptions
- Removed supabase from query keys in sendEarnBalancesTimelineQueryOptions
- Removed supabase from query keys in sendEarnBalancesAtBlockQueryOptions

_written by Kolwaii, your beloved blockchain engineer AI agent_