### PR TITLE
Native: fixed hiding tab bar detection

### DIFF
--- a/apps/expo/app/(tabs)/_layout.tsx
+++ b/apps/expo/app/(tabs)/_layout.tsx
@@ -7,7 +7,7 @@ import {
   IconWorldSearch,
 } from 'app/components/icons'
 import { useUser } from 'app/utils/useUser'
-import { Redirect, router, Stack, Tabs } from 'expo-router'
+import { Redirect, router, Stack, Tabs, useSegments } from 'expo-router'
 import AvatarMenuButton from 'app/components/AvatarMenuButton/AvatarMenuButton'
 import { useScrollDirection } from 'app/provider/scroll/ScrollDirectionContext'
 import { Animated } from 'react-native'
@@ -77,14 +77,26 @@ export default function Layout() {
   const { height, padding } = useTabBarSize()
   const translateY = useRef(new Animated.Value(0)).current
   const highlightColor = useHighlightColor()
+  const segments = useSegments()
+  const firstSegment = segments[0]
+  const prevDirectionRef = useRef(direction)
 
   useEffect(() => {
-    Animated.timing(translateY, {
-      toValue: direction === 'down' ? height : 0,
-      duration: 250,
-      useNativeDriver: true,
-    }).start()
-  }, [direction, height, translateY])
+    const prevDirection = prevDirectionRef.current
+    const changedToDown = prevDirection === 'up' && direction === 'down'
+    const changedToUp = prevDirection === 'down' && direction === 'up'
+    const shouldAnimate = firstSegment === '(tabs)' && (changedToDown || changedToUp)
+
+    if (shouldAnimate) {
+      Animated.timing(translateY, {
+        toValue: changedToDown ? height : 0,
+        duration: 250,
+        useNativeDriver: true,
+      }).start()
+    }
+
+    prevDirectionRef.current = direction
+  }, [direction, height, translateY, firstSegment])
 
   // Redirect to root if not logged in - this ensures the tabs layout is only shown for logged-in users
   if (!session) {


### PR DESCRIPTION
## Summary 

The PR enhances the tab bar detection by adding a new condition to animate the tab bar only when the user scrolls down or up and the first segment is '(tabs)'.


## Changes Made

- Added useSegments hook from expo-router
- Introduced a new condition to animate the tab bar
- Updated the useEffect hook to handle the new condition
- Added a ref to store the previous scroll direction

_written by Kolwaii, your beloved blockchain engineer AI agent_