### PR TITLE
refactor(seo): standardize simple pages to use SEO constants

### DIFF
--- a/apps/next/pages/404.tsx
+++ b/apps/next/pages/404.tsx
@@ -1,13 +1,11 @@
-import Head from 'next/head'
+import { NextSeo } from 'next-seo'
 import { UnknownScreen } from 'app/features/unknown/screen'
+import { PAGE_TITLES, PAGE_DESCRIPTIONS } from 'utils/seoHelpers'
 
 export default function Page() {
   return (
     <>
-      <Head>
-        <title>404 | Send</title>
-        <meta name="description" content="Not found. Send, Instant Payments." key="desc" />
-      </Head>
+      <NextSeo title={PAGE_TITLES.notFound} description={PAGE_DESCRIPTIONS.notFound} />
       <UnknownScreen />
     </>
   )

--- a/apps/next/pages/account/index.tsx
+++ b/apps/next/pages/account/index.tsx
@@ -4,14 +4,12 @@ import { NextSeo } from 'next-seo'
 import { userProtectedGetSSP } from 'utils/userProtected'
 import type { NextPageWithLayout } from '../_app'
 import { AccountScreenLayout } from 'app/features/account/AccountScreenLayout'
+import { PAGE_TITLES, PAGE_DESCRIPTIONS } from 'utils/seoHelpers'
 
 export const Page: NextPageWithLayout = () => {
   return (
     <>
-      <NextSeo
-        title="Send | Account"
-        description="Sendtags simplify transactions by replacing long wallet addresses with memorable identifiers."
-      />
+      <NextSeo title={PAGE_TITLES.account} description={PAGE_DESCRIPTIONS.account} />
     </>
   )
 }

--- a/apps/next/pages/activity.tsx
+++ b/apps/next/pages/activity.tsx
@@ -4,11 +4,12 @@ import { NextSeo } from 'next-seo'
 import { userProtectedGetSSP } from 'utils/userProtected'
 import type { NextPageWithLayout } from './_app'
 import { TopNav } from 'app/components/TopNav'
+import { PAGE_TITLES, PAGE_DESCRIPTIONS } from 'utils/seoHelpers'
 
 export const Page: NextPageWithLayout = () => {
   return (
     <>
-      <NextSeo title="Send | Activity" />
+      <NextSeo title={PAGE_TITLES.activity} description={PAGE_DESCRIPTIONS.activity} />
       <ActivityScreen />
     </>
   )

--- a/apps/next/pages/leaderboard.tsx
+++ b/apps/next/pages/leaderboard.tsx
@@ -1,16 +1,15 @@
 import { LeaderboardScreen } from 'app/features/leaderboard/screen'
 import { HomeLayout } from 'app/features/home/layout.web'
-import Head from 'next/head'
+import { NextSeo } from 'next-seo'
 import { userProtectedGetSSP } from 'utils/userProtected'
 import type { NextPageWithLayout } from './_app'
 import { TopNav } from 'app/components/TopNav'
+import { PAGE_TITLES, PAGE_DESCRIPTIONS } from 'utils/seoHelpers'
 
 export const Page: NextPageWithLayout = () => {
   return (
     <>
-      <Head>
-        <title>Send | Leaderboard</title>
-      </Head>
+      <NextSeo title={PAGE_TITLES.leaderboard} description={PAGE_DESCRIPTIONS.leaderboard} />
       <LeaderboardScreen />
     </>
   )

--- a/apps/next/pages/send/index.tsx
+++ b/apps/next/pages/send/index.tsx
@@ -4,11 +4,12 @@ import { userProtectedGetSSP } from 'utils/userProtected'
 import type { NextPageWithLayout } from '../_app'
 import { SendTopNav } from 'app/features/send/components/SendTopNav'
 import { HomeLayout } from 'app/features/home/layout.web'
+import { PAGE_TITLES, PAGE_DESCRIPTIONS } from 'utils/seoHelpers'
 
 export const Page: NextPageWithLayout = () => {
   return (
     <>
-      <NextSeo title="Send" description="Send" />
+      <NextSeo title={PAGE_TITLES.send} description={PAGE_DESCRIPTIONS.send} />
       <SendScreen />
     </>
   )


### PR DESCRIPTION
- Convert 404 page from Head to NextSeo with PAGE_TITLES and PAGE_DESCRIPTIONS
- Convert leaderboard page from Head to NextSeo with consistent constants
- Update account, send, and activity pages to use SEO constants
- Eliminate hardcoded titles and descriptions in favor of centralized constants
- Ensure consistent SEO patterns across simple pages