### PR TITLE
Add new links in bio

### DIFF
--- a/packages/app/components/icons/IconLinkInBio.tsx
+++ b/packages/app/components/icons/IconLinkInBio.tsx
@@ -7,11 +7,11 @@ import { IconXLogo } from './IconXLogo'
 import { IconTelegramLogo } from './IconTelegramLogo'
 import { IconYoutube } from './IconYoutube'
 import { IconDiscord } from './IconDiscord'
-import type { Database } from '@my/supabase/database-generated.types'
-import { XStack } from '@my/ui'
+import { type ColorTokens, XStack } from '@my/ui'
 import { IconWorldSearch } from './IconWorldSearch'
+import type { LinkInBioDomainNamesEnum } from 'app/utils/useLinkInBioMutation'
 
-export const domainColors = {
+export const domainColors: Partial<Record<LinkInBioDomainNamesEnum, ColorTokens>> = {
   X: 'black',
   Telegram: '$telegramBlue',
   Discord: '$discordPurple',
@@ -21,10 +21,7 @@ export const domainColors = {
   GitHub: 'black',
 } as const
 
-const domainIcons: Record<
-  Database['public']['Enums']['link_in_bio_domain_names'],
-  NamedExoticComponent<IconProps>
-> = {
+const domainIcons: Partial<Record<LinkInBioDomainNamesEnum, NamedExoticComponent<IconProps>>> = {
   X: IconXLogo,
   Telegram: IconTelegramLogo,
   YouTube: IconYoutube,

--- a/packages/app/features/account/components/linkInBio/screen.tsx
+++ b/packages/app/features/account/components/linkInBio/screen.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   FadeCard,
   Paragraph,
   SubmitButton,
@@ -99,8 +98,13 @@ export const LinkInBioScreen = () => {
   const socialLinksForm = (
     <YStack gap={'$5'}>
       <FadeCard elevation={'$0.75'}>
+        {errorMessage && (
+          <Paragraph marginBottom={'$5'} theme="red" color="$color9">
+            {errorMessage}
+          </Paragraph>
+        )}
         <YStack gap={'$4'}>
-          {LinkInBioDomainNamesEnum.options.map((domain_name) => {
+          {Object.values(LinkInBioDomainNamesEnum).map((domain_name) => {
             const currentHandle = domainHandles[domain_name] || ''
 
             return (

--- a/packages/app/utils/useLinkInBioMutation.ts
+++ b/packages/app/utils/useLinkInBioMutation.ts
@@ -6,15 +6,26 @@ import { useUser } from './useUser'
 import type { Database, TablesInsert } from '@my/supabase/database-generated.types'
 
 // Create Zod enum from database enum type
-export const LinkInBioDomainNamesEnum = z.enum([
-  'X',
-  'Instagram',
-  'YouTube',
-  'TikTok',
-  'GitHub',
-  'Telegram',
-  'Discord',
-] as const satisfies ReadonlyArray<Database['public']['Enums']['link_in_bio_domain_names']>)
+export const LinkInBioDomainNamesEnum: z.ZodType<
+  Database['public']['Enums']['link_in_bio_domain_names']
+> = z
+  .enum([
+    'X',
+    'Instagram',
+    'YouTube',
+    'TikTok',
+    'GitHub',
+    'Telegram',
+    'Discord',
+    'Facebook',
+    'OnlyFans',
+    'WhatsApp',
+    'Snapchat',
+    'Twitch',
+  ] as const)
+  .readonly()
+
+export type LinkInBioDomainNamesEnum = z.infer<typeof LinkInBioDomainNamesEnum>
 
 export const LinkInBioMutationSchema = z.array(
   z.object({
@@ -57,6 +68,11 @@ export const useLinkInBioMutation = () => {
         .select()
 
       if (error) {
+        if (error.code === '23514') {
+          throw new Error(
+            'Please entar a valid link handle and nothing more. Send will generate the link for you.'
+          )
+        }
         throw new Error(`Failed to upsert link in bio: ${error.message}`)
       }
 

--- a/packages/snaplet/.snaplet/dataModel.json
+++ b/packages/snaplet/.snaplet/dataModel.json
@@ -2903,20 +2903,6 @@
           "maxLength": null
         },
         {
-          "id": "public.link_in_bio.domain",
-          "name": "domain",
-          "columnName": "domain",
-          "type": "text",
-          "isRequired": false,
-          "kind": "scalar",
-          "isList": false,
-          "isGenerated": true,
-          "sequence": false,
-          "hasDefaultValue": false,
-          "isId": false,
-          "maxLength": null
-        },
-        {
           "id": "public.link_in_bio.created_at",
           "name": "created_at",
           "columnName": "created_at",
@@ -2941,6 +2927,20 @@
           "isGenerated": false,
           "sequence": false,
           "hasDefaultValue": true,
+          "isId": false,
+          "maxLength": null
+        },
+        {
+          "id": "public.link_in_bio.domain",
+          "name": "domain",
+          "columnName": "domain",
+          "type": "text",
+          "isRequired": false,
+          "kind": "scalar",
+          "isList": false,
+          "isGenerated": true,
+          "sequence": false,
+          "hasDefaultValue": false,
           "isId": false,
           "maxLength": null
         },
@@ -12938,16 +12938,31 @@
           "name": "Discord"
         },
         {
+          "name": "Facebook"
+        },
+        {
           "name": "GitHub"
         },
         {
           "name": "Instagram"
         },
         {
+          "name": "OnlyFans"
+        },
+        {
+          "name": "Snapchat"
+        },
+        {
           "name": "Telegram"
         },
         {
           "name": "TikTok"
+        },
+        {
+          "name": "Twitch"
+        },
+        {
+          "name": "WhatsApp"
         },
         {
           "name": "X"

--- a/packages/snaplet/.snaplet/snaplet-client.d.ts
+++ b/packages/snaplet/.snaplet/snaplet-client.d.ts
@@ -168,9 +168,9 @@ type Override = {
       user_id?: string;
       handle?: string;
       domain_name?: string;
-      domain?: string;
       created_at?: string;
       updated_at?: string;
+      domain?: string;
       users?: string;
     };
   }

--- a/packages/snaplet/.snaplet/snaplet.d.ts
+++ b/packages/snaplet/.snaplet/snaplet.d.ts
@@ -11,7 +11,7 @@ type Enum_net_request_status = 'ERROR' | 'PENDING' | 'SUCCESS';
 type Enum_pgtle_password_types = 'PASSWORD_TYPE_MD5' | 'PASSWORD_TYPE_PLAINTEXT' | 'PASSWORD_TYPE_SCRAM_SHA_256';
 type Enum_pgtle_pg_tle_features = 'clientauth' | 'passcheck';
 type Enum_public_key_type_enum = 'ES256';
-type Enum_public_link_in_bio_domain_names = 'Discord' | 'GitHub' | 'Instagram' | 'Telegram' | 'TikTok' | 'X' | 'YouTube';
+type Enum_public_link_in_bio_domain_names = 'Discord' | 'Facebook' | 'GitHub' | 'Instagram' | 'OnlyFans' | 'Snapchat' | 'Telegram' | 'TikTok' | 'Twitch' | 'WhatsApp' | 'X' | 'YouTube';
 type Enum_public_lookup_type_enum = 'address' | 'phone' | 'refcode' | 'sendid' | 'tag';
 type Enum_public_tag_status = 'available' | 'confirmed' | 'pending';
 type Enum_public_temporal_status = 'confirmed' | 'failed' | 'initialized' | 'sent' | 'submitted';
@@ -403,6 +403,10 @@ interface Table_vault_secrets {
   nonce: string | null;
   created_at: string;
   updated_at: string;
+}
+interface Table_supabase_migrations_seed_files {
+  path: string;
+  hash: string;
 }
 interface Table_public_send_account_created {
   chain_id: number;
@@ -987,6 +991,7 @@ interface Schema_supabase_functions {
 }
 interface Schema_supabase_migrations {
   schema_migrations: Table_supabase_migrations_schema_migrations;
+  seed_files: Table_supabase_migrations_seed_files;
 }
 interface Schema_temporal {
   send_account_transfers: Table_temporal_send_account_transfers;

--- a/packages/snaplet/snaplet.config.ts
+++ b/packages/snaplet/snaplet.config.ts
@@ -181,6 +181,9 @@ export default defineConfig({
       send_earn_withdraw: ({ row }) => {
         return row
       },
+      link_in_bio: ({ row }) => {
+        return row
+      },
     },
   },
 })

--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -2115,6 +2115,11 @@ export type Database = {
         | "GitHub"
         | "Telegram"
         | "Discord"
+        | "Facebook"
+        | "OnlyFans"
+        | "WhatsApp"
+        | "Snapchat"
+        | "Twitch"
       lookup_type_enum: "sendid" | "tag" | "refcode" | "address" | "phone"
       tag_status: "pending" | "confirmed" | "available"
       temporal_status:
@@ -2395,6 +2400,11 @@ export const Constants = {
         "GitHub",
         "Telegram",
         "Discord",
+        "Facebook",
+        "OnlyFans",
+        "WhatsApp",
+        "Snapchat",
+        "Twitch",
       ],
       lookup_type_enum: ["sendid", "tag", "refcode", "address", "phone"],
       tag_status: ["pending", "confirmed", "available"],

--- a/supabase/migrations/20250727064321_add_new_links_in_bio.sql
+++ b/supabase/migrations/20250727064321_add_new_links_in_bio.sql
@@ -1,0 +1,194 @@
+-- Step 1: Drop the generated column that depends on domain_name
+ALTER TABLE "public"."link_in_bio" DROP COLUMN IF EXISTS "domain";
+
+-- Step 2: Disable the updated_at trigger to prevent unwanted timestamp updates during schema changes
+ALTER TABLE "public"."link_in_bio" DISABLE TRIGGER "update_link_in_bio_updated_at_trigger";
+
+-- Step 3: Change domain_name column to text to remove enum dependency
+ALTER TABLE "public"."link_in_bio" ALTER COLUMN "domain_name" TYPE text;
+
+-- Step 4: Drop the old enum type
+DROP TYPE "public"."link_in_bio_domain_names";
+
+-- Step 5: Create new enum type with additional values
+CREATE TYPE "public"."link_in_bio_domain_names" AS ENUM (
+    'X',
+    'Instagram',
+    'YouTube',
+    'TikTok',
+    'GitHub',
+    'Telegram',
+    'Discord',
+    'Facebook',
+    'OnlyFans',
+    'WhatsApp',
+    'Snapchat',
+    'Twitch'
+);
+
+-- Step 6: Change domain_name column back to use the new enum
+ALTER TABLE "public"."link_in_bio" ALTER COLUMN "domain_name" TYPE "public"."link_in_bio_domain_names" USING "domain_name"::"public"."link_in_bio_domain_names";
+
+-- Step 7: Recreate the generated column with all platforms (including new ones)
+ALTER TABLE "public"."link_in_bio"
+ADD COLUMN "domain" "text" GENERATED ALWAYS AS(
+    CASE
+        WHEN "domain_name" = 'X' THEN 'x.com/'
+        WHEN "domain_name" = 'Instagram' THEN 'instagram.com/'
+        WHEN "domain_name" = 'Discord' THEN 'discord.gg/'
+        WHEN "domain_name" = 'YouTube' THEN 'youtube.com/@'
+        WHEN "domain_name" = 'TikTok' THEN 'tiktok.com/@'
+        WHEN "domain_name" = 'GitHub' THEN 'github.com/'
+        WHEN "domain_name" = 'Telegram' THEN 't.me/'
+        WHEN "domain_name" = 'Facebook' THEN 'facebook.com/'
+        WHEN "domain_name" = 'OnlyFans' THEN 'onlyfans.com/'
+        WHEN "domain_name" = 'WhatsApp' THEN 'wa.me/'
+        WHEN "domain_name" = 'Snapchat' THEN 'snapchat.com/@'
+        WHEN "domain_name" = 'Twitch' THEN 'twitch.tv/'
+        ELSE NULL
+    END
+) STORED;
+
+-- Step 8: Re-enable the updated_at trigger
+ALTER TABLE "public"."link_in_bio" ENABLE TRIGGER "update_link_in_bio_updated_at_trigger";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_friends()
+ RETURNS TABLE(avatar_url text, send_id int, x_username text, links_in_bio link_in_bio[], birthday date, tag citext, created_at timestamp with time zone)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+    RETURN QUERY
+        WITH ordered_referrals AS(
+            SELECT
+                DISTINCT ON (r.referred_id)
+                p.avatar_url,
+                p.send_id,
+                CASE WHEN p.is_public THEN p.x_username ELSE NULL END AS x_username,
+                CASE WHEN p.is_public THEN
+(SELECT array_agg(link_in_bio_row)
+                    FROM (
+                        SELECT ROW(
+                            id,
+                            user_id,
+                            handle,
+                            domain_name,
+                            created_at,
+                            updated_at,
+                            domain
+                        )::link_in_bio as link_in_bio_row
+                        FROM link_in_bio
+                        WHERE user_id = p.id AND handle IS NOT NULL
+                    ) sub)
+                ELSE NULL
+                END AS links_in_bio,
+                CASE WHEN p.is_public THEN p.birthday ELSE NULL END AS birthday,
+                t.name AS tag,
+                t.created_at,
+                COALESCE((
+                             SELECT
+                                 SUM(amount)
+                             FROM distribution_shares ds
+                             WHERE
+                                 ds.user_id = r.referred_id
+                               AND distribution_id >= 6), 0) AS send_score
+            FROM
+                referrals r
+                    LEFT JOIN affiliate_stats a ON a.user_id = r.referred_id
+                    LEFT JOIN profiles p ON p.id = r.referred_id
+                    LEFT JOIN tags t ON t.user_id = r.referred_id
+            WHERE
+                r.referrer_id = (SELECT auth.uid())
+                AND t.status = 'confirmed'::tag_status
+            ORDER BY
+                r.referred_id,
+                t.created_at DESC)
+        SELECT
+            o.avatar_url,
+            o.send_id,
+            o.x_username,
+            o.links_in_bio,
+            o.birthday,
+            o.tag,
+            o.created_at
+        FROM
+            ordered_referrals o
+        ORDER BY
+            send_score DESC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.profile_lookup(lookup_type lookup_type_enum, identifier text)
+ RETURNS SETOF profile_lookup_result
+ LANGUAGE plpgsql
+ IMMUTABLE SECURITY DEFINER
+AS $function$
+begin
+    if identifier is null or identifier = '' then raise exception 'identifier cannot be null or empty'; end if;
+    if lookup_type is null then raise exception 'lookup_type cannot be null'; end if;
+
+    RETURN QUERY
+    SELECT
+        case when p.id = ( select auth.uid() ) then p.id end,
+        p.avatar_url::text,
+        p.name::text,
+        p.about::text,
+        p.referral_code,
+        CASE WHEN p.is_public THEN p.x_username ELSE NULL END,
+        CASE WHEN p.is_public THEN p.birthday ELSE NULL END,
+        COALESCE(mt.name, t.name),
+        sa.address,
+        sa.chain_id,
+        case when current_setting('role')::text = 'service_role' then p.is_public
+            when p.is_public then true
+            else false end,
+        p.send_id,
+        ( select array_agg(t2.name::text)
+          from tags t2
+          join send_account_tags sat2 on sat2.tag_id = t2.id
+          join send_accounts sa2 on sa2.id = sat2.send_account_id
+          where sa2.user_id = p.id and t2.status = 'confirmed'::tag_status ),
+        case when p.id = ( select auth.uid() ) then sa.main_tag_id end,
+        mt.name::text,
+        CASE WHEN p.is_public THEN
+(SELECT array_agg(link_in_bio_row)
+            FROM (
+                SELECT ROW(
+                    id,
+                    user_id,
+                    handle,
+                    domain_name,
+                    created_at,
+                    updated_at,
+                    domain
+                )::link_in_bio as link_in_bio_row
+                FROM link_in_bio
+                WHERE user_id = p.id AND handle IS NOT NULL
+            ) sub)
+        ELSE NULL
+        END,
+        p.banner_url::text
+    from profiles p
+    join auth.users a on a.id = p.id
+    left join send_accounts sa on sa.user_id = p.id
+    left join tags mt on mt.id = sa.main_tag_id
+    left join send_account_tags sat on sat.send_account_id = sa.id
+    left join tags t on t.id = sat.tag_id and t.status = 'confirmed'::tag_status
+    where ((lookup_type = 'sendid' and p.send_id::text = identifier) or
+        (lookup_type = 'tag' and t.name = identifier::citext) or
+        (lookup_type = 'refcode' and p.referral_code = identifier) or
+        (lookup_type = 'address' and sa.address = identifier) or
+        (p.is_public and lookup_type = 'phone' and a.phone::text = identifier))
+    and (p.is_public
+     or ( select auth.uid() ) is not null
+     or current_setting('role')::text = 'service_role')
+    limit 1;
+end;
+$function$
+;
+
+

--- a/supabase/schemas/link_in_bio.sql
+++ b/supabase/schemas/link_in_bio.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS "public"."link_in_bio" (
     "handle" "text",
     "domain_name" "public"."link_in_bio_domain_names" NOT NULL,
     "domain" "text" GENERATED ALWAYS AS(
-          CASE
+         CASE
             WHEN "domain_name" = 'X' THEN 'x.com/'
             WHEN "domain_name" = 'Instagram' THEN 'instagram.com/'
             WHEN "domain_name" = 'Discord' THEN 'discord.gg/'
@@ -15,8 +15,13 @@ CREATE TABLE IF NOT EXISTS "public"."link_in_bio" (
             WHEN "domain_name" = 'TikTok' THEN 'tiktok.com/@'
             WHEN "domain_name" = 'GitHub' THEN 'github.com/'
             WHEN "domain_name" = 'Telegram' THEN 't.me/'
-            ELSE NULL
-          END
+            WHEN "domain_name" = 'Facebook' THEN 'facebook.com/'
+            WHEN "domain_name" = 'OnlyFans' THEN 'onlyfans.com/'
+            WHEN "domain_name" = 'WhatsApp' THEN 'wa.me/'
+            WHEN "domain_name" = 'Snapchat' THEN 'snapchat.com/@'
+            WHEN "domain_name" = 'Twitch' THEN 'twitch.tv/'
+        ELSE NULL
+    END
     ) STORED,
     "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,

--- a/supabase/schemas/referrals.sql
+++ b/supabase/schemas/referrals.sql
@@ -54,9 +54,20 @@ begin
         case when p.id = ( select auth.uid() ) then sa.main_tag_id end,
         mt.name::text,
         CASE WHEN p.is_public THEN
-            (SELECT array_agg((NULL::integer, NULL::uuid, sl2.handle, sl2.domain_name, sl2.domain, sl2.created_at, sl2.updated_at)::link_in_bio)
-            FROM link_in_bio sl2
-            WHERE sl2.user_id = p.id AND sl2.handle IS NOT NULL)
+(SELECT array_agg(link_in_bio_row)
+            FROM (
+                SELECT ROW(
+                    id,
+                    user_id,
+                    handle,
+                    domain_name,
+                    created_at,
+                    updated_at,
+                    domain
+                )::link_in_bio as link_in_bio_row
+                FROM link_in_bio
+                WHERE user_id = p.id AND handle IS NOT NULL
+            ) sub)
         ELSE NULL
         END,
         p.banner_url::text
@@ -434,9 +445,20 @@ BEGIN
                 p.send_id,
                 CASE WHEN p.is_public THEN p.x_username ELSE NULL END AS x_username,
                 CASE WHEN p.is_public THEN
-                    (SELECT array_agg((NULL::integer, NULL::uuid, sl.handle, sl.domain_name, sl.domain, sl.created_at, sl.updated_at)::link_in_bio)
-                     FROM link_in_bio sl
-                     WHERE sl.user_id = p.id AND sl.handle IS NOT NULL)
+(SELECT array_agg(link_in_bio_row)
+                    FROM (
+                        SELECT ROW(
+                            id,
+                            user_id,
+                            handle,
+                            domain_name,
+                            created_at,
+                            updated_at,
+                            domain
+                        )::link_in_bio as link_in_bio_row
+                        FROM link_in_bio
+                        WHERE user_id = p.id AND handle IS NOT NULL
+                    ) sub)
                 ELSE NULL
                 END AS links_in_bio,
                 CASE WHEN p.is_public THEN p.birthday ELSE NULL END AS birthday,

--- a/supabase/schemas/types.sql
+++ b/supabase/schemas/types.sql
@@ -21,7 +21,12 @@ CREATE TYPE "public"."link_in_bio_domain_names" AS ENUM (
 		'TikTok',
 		'GitHub',
 		'Telegram',
-		'Discord'
+		'Discord',
+        'Facebook',
+        'OnlyFans',
+        'WhatsApp',
+        'Snapchat',
+        'Twitch'
 );
 
 ALTER TYPE "public"."link_in_bio_domain_names" OWNER TO "postgres";


### PR DESCRIPTION
### TL;DR

Added new social media platforms to the Link in Bio feature and improved error handling.

### What changed?

- Added 5 new social media platforms to Link in Bio:
  - Facebook
  - OnlyFans
  - WhatsApp
  - Snapchat
  - Twitch
- Added error display in the LinkInBioScreen component to show validation errors
- Improved error handling for invalid link handles with a specific error message
- Updated database schema with a migration to support the new platforms
- Fixed profile lookup functions to properly handle the link_in_bio data structure

### How to test?

1. Navigate to the Link in Bio section in the account settings
2. Try adding links for the new platforms (Facebook, OnlyFans, WhatsApp, Snapchat, Twitch)
3. Test error handling by entering invalid handles
4. Verify that error messages are displayed correctly

### Why make this change?

This change expands the social media integration options for users, allowing them to connect more of their online presence to their profile. The improved error handling provides clearer feedback when users enter invalid information, enhancing the overall user experience.