### PR TITLE
feat: update Next.js profile pages to use HomeLayout instead of ProfileLayout

### DIFF
--- a/apps/next/pages/[tag]/index.tsx
+++ b/apps/next/pages/[tag]/index.tsx
@@ -7,11 +7,11 @@ import { userOnboarded } from 'utils/userOnboarded'
 import { SendtagSchema } from 'app/utils/zod/sendtag'
 import { assert } from 'app/utils/assert'
 import { createSupabaseAdminClient } from 'app/utils/supabase/admin'
-import { ProfileLayout } from 'app/features/profile/layout.web'
+import { HomeLayout } from 'app/features/home/layout.web'
 import { buildSeo } from 'utils/seo'
 import { generateProfileSeoData, type ProfileSeoData } from 'utils/seoHelpers'
+
 import { ProfileTopNav } from 'app/components/ProfileTopNav'
-import { HomeLayout } from 'app/features/home/layout.web'
 
 interface PageProps {
   sendid: number | null

--- a/apps/next/pages/profile/[sendid]/index.tsx
+++ b/apps/next/pages/profile/[sendid]/index.tsx
@@ -5,9 +5,11 @@ import type { GetServerSideProps, GetServerSidePropsContext } from 'next'
 import type { Database } from '@my/supabase/database.types'
 import { userOnboarded } from 'utils/userOnboarded'
 import { createSupabaseAdminClient } from 'app/utils/supabase/admin'
-import { ProfileLayout } from 'app/features/profile/layout.web'
+import { HomeLayout } from 'app/features/home/layout.web'
 import { buildSeo } from 'utils/seo'
 import { generateProfileSeoData, type ProfileSeoData } from 'utils/seoHelpers'
+
+import { ProfileTopNav } from 'app/components/ProfileTopNav'
 
 interface PageProps {
   sendid?: number
@@ -101,8 +103,6 @@ export const getServerSideProps = (async (ctx: GetServerSidePropsContext) => {
     type: 'profile',
   })
 
-  console.log('Server-side SEO generated:', seo)
-
   return {
     props: {
       sendid,
@@ -111,6 +111,6 @@ export const getServerSideProps = (async (ctx: GetServerSidePropsContext) => {
   }
 }) satisfies GetServerSideProps
 
-Page.getLayout = (children) => <ProfileLayout>{children}</ProfileLayout>
+Page.getLayout = (children) => <HomeLayout TopNav={<ProfileTopNav />}>{children}</HomeLayout>
 
 export default Page

--- a/packages/snaplet/.snaplet/snaplet.d.ts
+++ b/packages/snaplet/.snaplet/snaplet.d.ts
@@ -1033,7 +1033,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables: "temporal.send_earn_deposits" | {};
-    
+
   };
   "public.affiliate_stats": {
     parent: {
@@ -1044,7 +1044,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "public.profiles" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "storage.buckets": {
     parent: {
@@ -1057,7 +1057,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables:  | {};
     childDestinationsTables: "storage.objects" | "storage.s3_multipart_uploads" | "storage.s3_multipart_uploads_parts" | {};
-    
+
   };
   "public.chain_addresses": {
     parent: {
@@ -1068,7 +1068,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.distribution_shares": {
     parent: {
@@ -1080,7 +1080,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | "public.distributions" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.distribution_verification_values": {
     parent: {
@@ -1091,7 +1091,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "public.distributions" | {};
     childDestinationsTables: "public.distribution_verifications" | {};
-    
+
   };
   "public.distribution_verifications": {
     parent: {
@@ -1104,7 +1104,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | "public.distribution_verification_values" | "public.distributions" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.distributions": {
     parent: {
@@ -1118,7 +1118,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables:  | {};
     childDestinationsTables: "public.distribution_shares" | "public.distribution_verification_values" | "public.distribution_verifications" | "public.send_slash" | {};
-    
+
   };
   "_realtime.extensions": {
     parent: {
@@ -1129,7 +1129,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "_realtime.tenants" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.flow_state": {
     parent: {
@@ -1140,7 +1140,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables:  | {};
     childDestinationsTables: "auth.saml_relay_states" | {};
-    
+
   };
   "auth.identities": {
     parent: {
@@ -1151,7 +1151,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "private.leaderboard_referrals_all_time": {
     parent: {
@@ -1162,7 +1162,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.link_in_bio": {
     parent: {
@@ -1173,7 +1173,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.mfa_amr_claims": {
     parent: {
@@ -1184,7 +1184,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.sessions" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.mfa_challenges": {
     parent: {
@@ -1195,7 +1195,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.mfa_factors" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.mfa_factors": {
     parent: {
@@ -1206,7 +1206,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables: "auth.mfa_challenges" | {};
-    
+
   };
   "storage.objects": {
     parent: {
@@ -1217,7 +1217,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "storage.buckets" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.one_time_tokens": {
     parent: {
@@ -1228,7 +1228,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.profiles": {
     parent: {
@@ -1241,7 +1241,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables: "public.affiliate_stats" | "public.referrals" | {};
-    
+
   };
   "public.receipts": {
     parent: {
@@ -1252,7 +1252,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.referrals": {
     parent: {
@@ -1264,7 +1264,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "public.profiles" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.refresh_tokens": {
     parent: {
@@ -1275,7 +1275,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.sessions" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "storage.s3_multipart_uploads": {
     parent: {
@@ -1286,7 +1286,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "storage.buckets" | {};
     childDestinationsTables: "storage.s3_multipart_uploads_parts" | {};
-    
+
   };
   "storage.s3_multipart_uploads_parts": {
     parent: {
@@ -1298,7 +1298,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "storage.buckets" | "storage.s3_multipart_uploads" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.saml_providers": {
     parent: {
@@ -1309,7 +1309,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.sso_providers" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.saml_relay_states": {
     parent: {
@@ -1321,7 +1321,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.flow_state" | "auth.sso_providers" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.send_account_credentials": {
     parent: {
@@ -1333,7 +1333,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "public.send_accounts" | "public.webauthn_credentials" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.send_account_tags": {
     parent: {
@@ -1345,7 +1345,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "public.send_accounts" | "public.tags" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.send_accounts": {
     parent: {
@@ -1358,7 +1358,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | "public.tags" | {};
     childDestinationsTables: "public.send_account_credentials" | "public.send_account_tags" | {};
-    
+
   };
   "temporal.send_earn_deposits": {
     parent: {
@@ -1369,7 +1369,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "public.activity" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.send_slash": {
     parent: {
@@ -1380,7 +1380,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "public.distributions" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.sessions": {
     parent: {
@@ -1392,7 +1392,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables: "auth.mfa_amr_claims" | "auth.refresh_tokens" | {};
-    
+
   };
   "auth.sso_domains": {
     parent: {
@@ -1403,7 +1403,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.sso_providers" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "auth.sso_providers": {
     parent: {
@@ -1416,7 +1416,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables:  | {};
     childDestinationsTables: "auth.saml_providers" | "auth.saml_relay_states" | "auth.sso_domains" | {};
-    
+
   };
   "public.tag_receipts": {
     parent: {
@@ -1427,7 +1427,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "public.tags" | {};
     childDestinationsTables:  | {};
-    
+
   };
   "public.tags": {
     parent: {
@@ -1440,7 +1440,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables: "public.send_account_tags" | "public.send_accounts" | "public.tag_receipts" | {};
-    
+
   };
   "_realtime.tenants": {
     parent: {
@@ -1451,7 +1451,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables:  | {};
     childDestinationsTables: "_realtime.extensions" | {};
-    
+
   };
   "auth.users": {
     parent: {
@@ -1477,7 +1477,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables:  | {};
     childDestinationsTables: "auth.identities" | "auth.mfa_factors" | "auth.one_time_tokens" | "auth.sessions" | "private.leaderboard_referrals_all_time" | "public.activity" | "public.chain_addresses" | "public.distribution_shares" | "public.distribution_verifications" | "public.link_in_bio" | "public.profiles" | "public.receipts" | "public.send_accounts" | "public.tags" | "public.webauthn_credentials" | {};
-    
+
   };
   "public.webauthn_credentials": {
     parent: {
@@ -1488,7 +1488,7 @@ interface Tables_relationships {
     };
     parentDestinationsTables: "auth.users" | {};
     childDestinationsTables: "public.send_account_credentials" | {};
-    
+
   };
 }
 //#endregion


### PR DESCRIPTION
Update both [tag]/index.tsx and profile/[sendid]/index.tsx to:
- Import HomeLayout instead of ProfileLayout
- Use HomeLayout in getLayout function

This ensures profile pages now use the standard home layout with
bottom navigation and sidebar support, and can display the ProfileTopNav
component properly on mobile.