### PR TITLE
Native: fix expo blur version

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -39,7 +39,7 @@
     "expo": "~52.0.23",
     "expo-apple-authentication": "~7.1.2",
     "expo-application": "~6.0.2",
-    "expo-blur": "^14.1.5",
+    "expo-blur": "~14.0.3",
     "expo-build-properties": "~0.13.2",
     "expo-clipboard": "~7.0.1",
     "expo-constants": "~17.0.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,7 @@
     "@tamagui/themes": "^1.126.1",
     "@tamagui/toast": "^1.126.1",
     "@ts-react/form": "^1.8.3",
-    "expo-blur": "^14.1.5",
+    "expo-blur": "~14.0.3",
     "expo-linear-gradient": "~14.0.1",
     "moti": "^0.29.0",
     "react-hook-form": "^7.48.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6336,7 +6336,7 @@ __metadata:
     "@tamagui/themes": "npm:^1.126.1"
     "@tamagui/toast": "npm:^1.126.1"
     "@ts-react/form": "npm:^1.8.3"
-    expo-blur: "npm:^14.1.5"
+    expo-blur: "npm:~14.0.3"
     expo-linear-gradient: "npm:~14.0.1"
     moti: "npm:^0.29.0"
     react-hook-form: "npm:^7.48.2"
@@ -20022,7 +20022,7 @@ __metadata:
     expo: "npm:~52.0.23"
     expo-apple-authentication: "npm:~7.1.2"
     expo-application: "npm:~6.0.2"
-    expo-blur: "npm:^14.1.5"
+    expo-blur: "npm:~14.0.3"
     expo-build-properties: "npm:~0.13.2"
     expo-clipboard: "npm:~7.0.1"
     expo-constants: "npm:~17.0.3"
@@ -20098,14 +20098,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-blur@npm:^14.1.5":
-  version: 14.1.5
-  resolution: "expo-blur@npm:14.1.5"
+"expo-blur@npm:~14.0.3":
+  version: 14.0.3
+  resolution: "expo-blur@npm:14.0.3"
   peerDependencies:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 10/2cfb444e7fa8425e4c12a10bee1c0ec58c9fd9137ad5638fb5f57f4308a3a6fb628f1fe5322864c1d32a2d7bfa04c65d08474f91a7ec162bc143ce60a5d4f17b
+  checksum: 10/c69dfb542530dae4ca66caf341b8e72f1555ef0cf700c94603e487a31d53f31885a03f3aadd208e9d531969dbcd558856f4475ccb9b77a37580fc6062dee4cda
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary 

The PR updates the `expo-blur` version to `~14.0.3` in two package.json files.


## Changes Made

- Update `expo-blur` version to `~14.0.3`
- Modify `apps/expo/package.json` and `packages/ui/package.json`

_written by Kolwaii, your beloved blockchain engineer AI agent_