### PR TITLE
Fixed order of providers

### DIFF
--- a/packages/app/provider/index.tsx
+++ b/packages/app/provider/index.tsx
@@ -51,9 +51,9 @@ const Providers = compose([
   QueryClientProvider,
   UniversalThemeProvider,
   SafeAreaProvider,
+  CoinsProvider,
   TamaguiProvider,
   ToastProvider,
   ScrollDirectionProvider,
-  CoinsProvider,
   ActivityDetailsProvider,
 ])


### PR DESCRIPTION
## CoinsProvider context unavailable in portal components on Android

### Problem
The `useCoins` hook was throwing "useCoins must be used within a CoinsProvider" errors specifically on Android when navigating to the send form (`/send/form`). This occurred in the `TokenBalance` component inside `CoinFieldItem`, which is rendered within a Tamagui Sheet/Portal.

**Root Cause:** The `CoinsProvider` was positioned after `TamaguiProvider` in the provider chain. Since Tamagui portals (used by Sheet components) render their content outside the normal React tree, components inside portals couldn't access the `CoinsProvider` context.

### The Issue Flow
1. User navigates to send form
2. `CoinField` component renders inside a Tamagui Sheet (portal)
3. `TokenBalance` component calls `useCoins()` hook
4. Portal content is rendered outside the provider tree
5. Context is `undefined` → Error thrown

### Solution
Moved `CoinsProvider` **before** `TamaguiProvider` in the provider composition chain, ensuring that portal content has access to the coins context.

**Before:**
```tsx
const Providers = compose([
  WagmiProvider,
  OnchainKitProvider,
  QueryClientProvider,
  UniversalThemeProvider,
  SafeAreaProvider,
  TamaguiProvider,        // Portal host created here
  ToastProvider,
  ScrollDirectionProvider,
  CoinsProvider,          // ❌ Too late - portals can't access this
  ActivityDetailsProvider,
])
```

**After:**
```tsx
const Providers = compose([
  WagmiProvider,
  OnchainKitProvider,
  QueryClientProvider,
  UniversalThemeProvider,
  SafeAreaProvider,
  CoinsProvider,          // ✅ Now available to portal content
  TamaguiProvider,        // Portal host created here
  ToastProvider,
  ScrollDirectionProvider,
  ActivityDetailsProvider,
])
```

### Why This Only Affected Android
The timing and rendering behavior of portals can vary between platforms. Android's React Native implementation likely had different timing for portal rendering, making the context unavailability more apparent during navigation.

### Testing
- ✅ Navigation to `/send/form` now works on both iOS and Android
- ✅ Coin selection dropdown renders without errors
- ✅ All existing functionality preserved

---

This fix ensures that any component rendered inside Tamagui portals (Sheets, Dialogs, etc.) can access the coins context properly across all platforms.