### PR TITLE
Native: fixed forms height for android

### DIFF
--- a/packages/app/features/account/components/editProfile/screen.tsx
+++ b/packages/app/features/account/components/editProfile/screen.tsx
@@ -185,11 +185,16 @@ function EditProfileForm({ profile, onSave }: { profile: Tables<'profiles'>; onS
         $gtSm: {
           maxWidth: '100%',
         },
+        ...(Platform.OS === 'android' && {
+          minHeight: 'auto',
+          height: 'auto',
+          flex: 0,
+        }),
       }}
       onSubmit={handleSubmit}
     >
       {({ name, about, isPublic }) => (
-        <YStack gap={'$3.5'} $platform-android={{ height: 500 }}>
+        <YStack gap={'$3.5'}>
           <FadeCard>
             <FieldWithLabel label={'Name'} gap={'$2'}>
               {name}

--- a/packages/app/features/account/components/personalInfo/screen.tsx
+++ b/packages/app/features/account/components/personalInfo/screen.tsx
@@ -157,10 +157,15 @@ export const PersonalInfoScreen = () => {
         $gtSm: {
           maxWidth: '100%',
         },
+        ...(Platform.OS === 'android' && {
+          minHeight: 'auto',
+          height: 'auto',
+          flex: 0,
+        }),
       }}
     >
       {({ birthday, xUsername }) => (
-        <YStack gap={'$3.5'} $platform-android={{ height: 500 }}>
+        <YStack gap={'$3.5'}>
           <FadeCard>
             <FieldWithLabel label={'Date of Birth'} additionalInfo={'(non-editable)'} gap={'$2'}>
               {birthday}

--- a/packages/app/features/auth/onboarding/screen.tsx
+++ b/packages/app/features/auth/onboarding/screen.tsx
@@ -170,7 +170,7 @@ export function OnboardingScreen() {
         }}
       >
         <FormProvider {...form}>
-          <YStack w={'100%'} ai={'center'} height={112}>
+          <YStack w={'100%'} ai={'center'}>
             <SchemaForm
               form={form}
               onSubmit={handleSubmit}
@@ -220,6 +220,11 @@ export function OnboardingScreen() {
                 $gtSm: {
                   maxWidth: '100%',
                 },
+                ...(Platform.OS === 'android' && {
+                  minHeight: 'auto',
+                  height: 'auto',
+                  flex: 0,
+                }),
                 style: { justifyContent: 'space-between' },
               }}
             >

--- a/packages/app/features/auth/sign-up/screen.tsx
+++ b/packages/app/features/auth/sign-up/screen.tsx
@@ -204,7 +204,7 @@ export const SignUpScreen = () => {
         }}
       >
         <FormProvider {...form}>
-          <YStack w={'100%'} ai={'center'} height={200}>
+          <YStack w={'100%'} ai={'center'}>
             <SchemaForm
               form={form}
               onSubmit={handleSubmit}
@@ -263,6 +263,11 @@ export const SignUpScreen = () => {
                 $gtSm: {
                   maxWidth: '100%',
                 },
+                ...(Platform.OS === 'android' && {
+                  minHeight: 'auto',
+                  height: 'auto',
+                  flex: 0,
+                }),
                 style: { justifyContent: 'space-between' },
               }}
             >


### PR DESCRIPTION
## Summary 

Fixed forms height for Android devices by setting minHeight, height, and flex to 'auto' and 0 respectively.


## Changes Made

- Fixed forms height for Android devices
- Removed hardcoded height for YStack components
- Updated formProps for Android devices

_written by Kolwaii, your beloved blockchain engineer AI agent_