### PR TITLE
Native: trades screen fixes for android

### DIFF
--- a/packages/app/features/swap/form/RiskDialog/SwapRiskDialog.tsx
+++ b/packages/app/features/swap/form/RiskDialog/SwapRiskDialog.tsx
@@ -82,7 +82,7 @@ const SwapRiskDialog = () => {
                 <Check color={'$black'} />
               </Checkbox.Indicator>
             </Checkbox>
-            <Label htmlFor={id} cursor={'pointer'} lineHeight={0}>
+            <Label htmlFor={id} cursor={'pointer'} lineHeight={20}>
               I have read and understand the risks involved.
             </Label>
           </XStack>

--- a/packages/app/features/swap/form/screen.tsx
+++ b/packages/app/features/swap/form/screen.tsx
@@ -725,7 +725,7 @@ export const Slippage = ({
         </XStack>
       </XStack>
       {isOpen && (
-        <XStack gap={'$2'} columnGap={'$2'} flexWrap={'wrap'} flex={1}>
+        <XStack gap={'$2'} columnGap={'$2'} flexWrap={'wrap'}>
           {SLIPPAGE_OPTIONS.map((slippageOption) => (
             <Button
               // @ts-expect-error tamagui is tripping here


### PR DESCRIPTION
## Summary 

The PR introduces minor UI fixes to the trades screen for Android, adjusting the label line height and removing the flex property from an XStack component.


## Changes Made

- Adjusted label line height in SwapRiskDialog
- Removed flex property from XStack in Slippage component

_written by Kolwaii, your beloved blockchain engineer AI agent_