### PR TITLE
no worklets for chart on web

### DIFF
--- a/apps/next/pages/_app.tsx
+++ b/apps/next/pages/_app.tsx
@@ -2,6 +2,8 @@ import '../public/reset.css'
 import '../styles/globals.css'
 
 import 'raf/polyfill'
+import 'react-native-gesture-handler'
+import 'react-native-reanimated'
 
 import '@my/ui/src/config/fonts.css'
 

--- a/packages/app/features/home/TokenDetails.tsx
+++ b/packages/app/features/home/TokenDetails.tsx
@@ -3,17 +3,32 @@ import type { CoinWithBalance } from 'app/data/coins'
 import { TokenDetailsHeader } from 'app/features/home/TokenDetailsHeader'
 import { TokenAbout } from 'app/features/home/TokenAbout'
 import { TokenKeyMetrics } from './TokenKeyMetrics'
-import { useCoinData } from 'app/utils/coin-gecko'
+import { useCoinData, type CoinData } from 'app/utils/coin-gecko'
 import { TokenChartSection } from 'app/features/home/TokenChartSection'
 
-export const TokenDetails = ({ coin }: { coin: CoinWithBalance }) => {
-  const { data: coinData, isLoading: isLoadingCoinData } = useCoinData(coin.coingeckoTokenId)
+export const TokenDetails = ({
+  coin,
+  serverCoinData,
+}: {
+  coin: CoinWithBalance
+  serverCoinData?: CoinData
+}) => {
+  const { data: fetchedCoinData, isLoading: isLoadingCoinData } = useCoinData(coin.coingeckoTokenId)
+  const coinData = serverCoinData ?? fetchedCoinData
   return (
-    <YStack f={1} gap="$3" $gtLg={{ w: '45%', pb: '$0' }} pb="$4">
+    <YStack f={1} gap="$5" $gtLg={{ w: '45%', pb: '$0' }} pb="$4">
       <TokenDetailsHeader coin={coin} />
       <TokenChartSection coin={coin} />
-      <TokenKeyMetrics coin={coin} coinData={coinData} isLoadingCoinData={isLoadingCoinData} />
-      <TokenAbout coin={coin} coinData={coinData} isLoadingCoinData={isLoadingCoinData} />
+      <TokenKeyMetrics
+        coin={coin}
+        coinData={coinData}
+        isLoadingCoinData={isLoadingCoinData && !serverCoinData}
+      />
+      <TokenAbout
+        coin={coin}
+        coinData={coinData}
+        isLoadingCoinData={isLoadingCoinData && !serverCoinData}
+      />
     </YStack>
   )
 }

--- a/packages/app/features/home/charts/shared/components/ChartCardSection.tsx
+++ b/packages/app/features/home/charts/shared/components/ChartCardSection.tsx
@@ -1,0 +1,38 @@
+import { Card, H4, Spinner, YStack } from '@my/ui'
+
+export function ChartCardSection({
+  title,
+  isLoading,
+  children,
+}: {
+  title: string
+  isLoading: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <YStack gap={'$3'}>
+      <H4 fontWeight={600} size={'$7'}>
+        {title}
+      </H4>
+      <Card padded size={'$5'} w={'100%'} elevation={'$0.75'}>
+        <YStack gap={'$3'} position="relative">
+          {children}
+          {isLoading ? (
+            <YStack
+              position="absolute"
+              left={0}
+              top={0}
+              right={0}
+              bottom={0}
+              ai="center"
+              jc="center"
+              pointerEvents="none"
+            >
+              <Spinner size="small" color={'$color12'} />
+            </YStack>
+          ) : null}
+        </YStack>
+      </Card>
+    </YStack>
+  )
+}

--- a/packages/app/features/home/charts/shared/components/ChartExtremeLabels.tsx
+++ b/packages/app/features/home/charts/shared/components/ChartExtremeLabels.tsx
@@ -1,0 +1,101 @@
+import { Paragraph, YStack } from '@my/ui'
+import { useMemo, useState } from 'react'
+import formatAmount from 'app/utils/formatAmount'
+import { useChartData } from '@my/ui'
+
+export function ChartExtremeLabels({ decimals, active }: { decimals: number; active: boolean }) {
+  const { currentPath, width, height } = useChartData() as unknown as {
+    currentPath: { points: { x: number; y: number; originalX: number; originalY: number }[] } | null
+    width: number
+    height: number
+  }
+
+  // Measure actual label sizes to position precisely across themes/densities
+  const [maxSize, setMaxSize] = useState({ w: 72, h: 20 })
+  const [minSize, setMinSize] = useState({ w: 72, h: 20 })
+  const spacing = 6
+
+  const labels = useMemo(() => {
+    if (!currentPath || !currentPath.points || currentPath.points.length === 0) return null
+
+    let minP = currentPath.points[0]
+    let maxP = currentPath.points[0]
+    for (const p of currentPath.points) {
+      if (!p) continue
+      if (p.originalY < (minP?.originalY ?? Number.POSITIVE_INFINITY)) minP = p
+      if (p.originalY > (maxP?.originalY ?? Number.NEGATIVE_INFINITY)) maxP = p
+    }
+    if (!minP || !maxP) return null
+
+    const computeX = (p: typeof minP, w: number) =>
+      Math.min(Math.max(p.x - w / 2, 0), Math.max(0, width - w))
+
+    // Max: prefer above; if not enough space, place below; else center within chart
+    const maxAboveTop = maxP.y - maxSize.h - spacing
+    const maxBelowTop = maxP.y + spacing
+    const maxTop =
+      maxAboveTop >= 0
+        ? maxAboveTop
+        : maxBelowTop + maxSize.h <= height
+          ? maxBelowTop
+          : Math.min(Math.max(maxP.y - maxSize.h / 2, 0), height - maxSize.h)
+    const maxLeft = computeX(maxP, maxSize.w)
+
+    // Min: prefer below; if not enough space, place above; else center within chart
+    const minBelowTop = minP.y + spacing
+    const minAboveTop = minP.y - minSize.h - spacing
+    const minTop =
+      minBelowTop + minSize.h <= height
+        ? minBelowTop
+        : minAboveTop >= 0
+          ? minAboveTop
+          : Math.min(Math.max(minP.y - minSize.h / 2, 0), height - minSize.h)
+    const minLeft = computeX(minP, minSize.w)
+
+    return {
+      max: { x: maxLeft, y: maxTop, text: `$${formatAmount(maxP.originalY, 9, decimals)}` },
+      min: { x: minLeft, y: minTop, text: `$${formatAmount(minP.originalY, 9, decimals)}` },
+    }
+  }, [currentPath, width, height, decimals, maxSize, minSize])
+
+  if (!labels || active) return null
+
+  return (
+    <YStack style={{ position: 'absolute', left: 0, top: 0, width, height }} pointerEvents="none">
+      <YStack
+        position="absolute"
+        left={labels.max.x}
+        top={labels.max.y} // this offset works for now
+        bg={'$color2'}
+        px={'$1.5'}
+        py={'$0.5'}
+        br={'$2'}
+        onLayout={(e) => {
+          const { width: w, height: h } = e.nativeEvent.layout
+          if (w && h && (w !== maxSize.w || h !== maxSize.h)) setMaxSize({ w, h })
+        }}
+      >
+        <Paragraph size={'$3'} color={'$color12'} fontWeight={500}>
+          {labels.max.text}
+        </Paragraph>
+      </YStack>
+      <YStack
+        position="absolute"
+        left={labels.min.x}
+        top={labels.min.y}
+        bg={'$color2'}
+        px={'$1.5'}
+        py={'$0.5'}
+        br={'$2'}
+        onLayout={(e) => {
+          const { width: w, height: h } = e.nativeEvent.layout
+          if (w && h && (w !== minSize.w || h !== minSize.h)) setMinSize({ w, h })
+        }}
+      >
+        <Paragraph size={'$3'} color={'$color12'} fontWeight={500}>
+          {labels.min.text}
+        </Paragraph>
+      </YStack>
+    </YStack>
+  )
+}

--- a/packages/app/features/home/charts/shared/components/ChartLineSection.tsx
+++ b/packages/app/features/home/charts/shared/components/ChartLineSection.tsx
@@ -1,0 +1,68 @@
+import { ChartPathProvider, ChartPath, ChartDot } from '@my/ui'
+import { useMemo } from 'react'
+import { View } from 'react-native'
+
+export function ChartLineSection({
+  points,
+  smoothed,
+  width,
+  stroke,
+  endPadding = 0,
+  childrenBeforePath,
+  childrenAfterPath,
+  pathProps = {},
+}: {
+  points: { x: number; y: number }[]
+  smoothed: { x: number; y: number }[]
+  width: number
+  stroke: string
+  endPadding?: number
+  childrenBeforePath?: React.ReactNode
+  childrenAfterPath?: React.ReactNode
+  pathProps?: Record<string, unknown>
+}) {
+  const H = 200
+  const data = useMemo(
+    () => ({ points: smoothed, nativePoints: points, curve: 'basis' as const }),
+    [points, smoothed]
+  )
+
+  return (
+    <View style={{ width }}>
+      <ChartPathProvider
+        data={data}
+        width={width}
+        height={H}
+        color={stroke}
+        selectedColor={stroke}
+        endPadding={endPadding}
+      >
+        {/* Scrub readout in normal flow above the chart */}
+        {childrenBeforePath}
+        {/* Fixed-height chart area below */}
+        <View style={{ height: H, width }}>
+          <ChartPath
+            width={width}
+            height={H}
+            stroke={stroke}
+            fill="none"
+            selectedStrokeWidth={3}
+            strokeWidth={3.5}
+            panGestureHandlerProps={pathProps as never}
+            onScrub={
+              typeof pathProps?.onScrub === 'function'
+                ? (pathProps.onScrub as (payload: {
+                    active: boolean
+                    ox?: number
+                    oy?: number
+                  }) => void)
+                : undefined
+            }
+          />
+          {childrenAfterPath}
+          <ChartDot color={stroke} size={10} />
+        </View>
+      </ChartPathProvider>
+    </View>
+  )
+}

--- a/packages/app/features/home/charts/shared/components/TimeframeTabs.tsx
+++ b/packages/app/features/home/charts/shared/components/TimeframeTabs.tsx
@@ -1,0 +1,38 @@
+import { Button, ButtonText, XStack } from '@my/ui'
+import { TIMEFRAMES, type Timeframe } from '../../shared/timeframes'
+
+export function TimeframeTabs({
+  value,
+  onChange,
+  isDark,
+}: {
+  value: Timeframe
+  onChange: (tf: Timeframe) => void
+  isDark?: boolean
+}) {
+  return (
+    <XStack ai="center" jc="space-around" gap="$3" flexWrap="wrap">
+      {TIMEFRAMES.map((label) => {
+        const active = value === label
+        return (
+          <Button
+            key={label}
+            chromeless
+            unstyled
+            onPress={() => onChange(label)}
+            borderBottomColor={isDark ? '$primary' : '$color12'}
+            borderBottomWidth={active ? 1 : 0}
+          >
+            <ButtonText
+              color={active ? '$color12' : '$silverChalice'}
+              textTransform="uppercase"
+              size={'$3'}
+            >
+              {label}
+            </ButtonText>
+          </Button>
+        )
+      })}
+    </XStack>
+  )
+}

--- a/packages/app/features/home/charts/shared/timeframes.ts
+++ b/packages/app/features/home/charts/shared/timeframes.ts
@@ -1,0 +1,49 @@
+export const TIMEFRAMES = ['1D', '1W', '1M', '3M', '6M', '1Y', 'ALL'] as const
+export type Timeframe = (typeof TIMEFRAMES)[number]
+
+export function getDaysForTimeframe(tf: Timeframe): string {
+  switch (tf) {
+    case '1D':
+      return '1'
+    case '1W':
+      return '7'
+    case '1M':
+      return '30'
+    case '3M':
+      return '90'
+    case '6M':
+      return '180'
+    case '1Y':
+      return '365'
+    case 'ALL':
+      return 'max'
+    default:
+      return '1'
+  }
+}
+
+export function getInterpolationRange(tf: Timeframe): number {
+  switch (tf) {
+    case '1D':
+      return 120
+    case '1W':
+      return 160
+    case '1M':
+      return 200
+    case '3M':
+      return 220
+    case '6M':
+      return 240
+    case '1Y':
+      return 280
+    case 'ALL':
+      return 300
+    default:
+      return 120
+  }
+}
+
+export function getCgParams(_tf: Timeframe): { interval: string | null; precision: string | null } {
+  // unify on higher precision; interval is null for CG market_chart
+  return { interval: null, precision: 'full' }
+}

--- a/packages/app/features/home/charts/shared/useScrubState.native.ts
+++ b/packages/app/features/home/charts/shared/useScrubState.native.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import { useChartData } from '@my/ui'
+import { useAnimatedReaction, runOnJS } from 'react-native-reanimated'
+
+export function useScrubState() {
+  const { isActive, originalX, originalY } = useChartData()
+  const [price, setPrice] = useState<number | null>(null)
+  const [ts, setTs] = useState<number | null>(null)
+  const [active, setActive] = useState(false)
+
+  useAnimatedReaction(
+    () => ({ active: isActive.value, ox: originalX.value, oy: originalY.value }),
+    (v) => {
+      runOnJS(setActive)(!!v.active)
+      if (v.active && v.oy !== '') {
+        runOnJS(setPrice)(Number(v.oy))
+        if (v.ox !== '') runOnJS(setTs)(Number(v.ox))
+      } else {
+        runOnJS(setPrice)(null)
+        runOnJS(setTs)(null)
+      }
+    }
+  )
+
+  return { active, price, ts, onScrub: undefined as unknown as never }
+}

--- a/packages/app/features/home/charts/shared/useScrubState.web.ts
+++ b/packages/app/features/home/charts/shared/useScrubState.web.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+
+export function useScrubState() {
+  const [price, setPrice] = useState<number | null>(null)
+  const [ts, setTs] = useState<number | null>(null)
+  const [active, setActive] = useState(false)
+
+  function onScrub(p: { active: boolean; ox?: number; oy?: number }) {
+    setActive(!!p.active)
+    if (p.active && typeof p.oy === 'number') {
+      setPrice(p.oy)
+      if (typeof p.ox === 'number') setTs(p.ox)
+    } else {
+      setPrice(null)
+      setTs(null)
+    }
+  }
+
+  return { active, price, ts, onScrub }
+}

--- a/packages/app/features/home/charts/shared/useTokenChartData.ts
+++ b/packages/app/features/home/charts/shared/useTokenChartData.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react'
+import { useTokenMarketChart, toChartPointsFromPrices } from 'app/utils/coin-gecko'
+import {
+  getCgParams,
+  getDaysForTimeframe,
+  getInterpolationRange,
+  type Timeframe,
+} from './timeframes'
+import { monotoneCubicInterpolation } from '@my/ui'
+
+export function useTokenChartData(tokenId: string, tf: Timeframe) {
+  const { interval, precision } = getCgParams(tf)
+  const days = getDaysForTimeframe(tf)
+
+  const { data, isLoading, isError } = useTokenMarketChart(tokenId, {
+    days,
+    interval: interval ?? undefined,
+    precision: precision ?? undefined,
+  })
+
+  const points = useMemo(() => {
+    if (!data?.prices) return [] as { x: number; y: number }[]
+    return toChartPointsFromPrices({ prices: data.prices })
+  }, [data?.prices])
+
+  const smoothed = useMemo(() => {
+    if (!points.length) return [] as { x: number; y: number }[]
+    return monotoneCubicInterpolation({
+      data: points,
+      includeExtremes: true,
+      range: getInterpolationRange(tf),
+    })
+  }, [points, tf])
+
+  const first = points[0]?.y
+  const last = points.at(-1)?.y
+  const change = first && last ? ((last - first) / first) * 100 : null
+
+  return {
+    points,
+    smoothed,
+    last: last ?? 0,
+    change,
+    isLoading,
+    isError,
+  }
+}

--- a/packages/app/features/home/screen.tsx
+++ b/packages/app/features/home/screen.tsx
@@ -36,13 +36,16 @@ import { useHoverStyles } from 'app/utils/useHoverStyles'
 import { investmentCoins } from 'app/data/coins'
 import { CoinSheet } from 'app/components/CoinSheet'
 import { Link } from 'solito/link'
-import { baseMainnet, usdcAddress } from '@my/wagmi'
 import { Platform } from 'react-native'
 import { usePathname } from 'app/utils/usePathname'
 import { useMultipleTokensMarketData } from 'app/utils/coin-gecko'
 import { formatUnits } from 'viem'
 
-export function HomeScreen() {
+export function HomeScreen({
+  serverCoinData,
+}: {
+  serverCoinData?: import('app/utils/coin-gecko').CoinData | null
+} = {}) {
   const media = useMedia()
   const router = useRouter()
   const supabase = useSupabase()
@@ -88,6 +91,7 @@ export function HomeScreen() {
                     opacity: 0,
                     y: media.gtLg ? 0 : 300,
                   }}
+                  serverCoinData={serverCoinData ?? undefined}
                 />
               )
           }
@@ -97,7 +101,11 @@ export function HomeScreen() {
   )
 }
 
-function HomeBody(props: XStackProps) {
+function HomeBody(
+  props: XStackProps & {
+    serverCoinData?: import('app/utils/coin-gecko').CoinData | null
+  }
+) {
   const { coin: selectedCoin, isLoading } = useCoinFromTokenParam()
   const [queryParams] = useRootScreenParams()
 
@@ -155,7 +163,12 @@ function HomeBody(props: XStackProps) {
             case Platform.OS !== 'web':
               return null
             case selectedCoin !== undefined:
-              return <TokenDetails coin={selectedCoin} />
+              return (
+                <TokenDetails
+                  coin={selectedCoin}
+                  serverCoinData={props.serverCoinData ?? undefined}
+                />
+              )
             case queryParams.token === 'investments':
               return <InvestmentsBody />
             case queryParams.token === 'stables':

--- a/packages/app/utils/coin-gecko/index.native.tsx
+++ b/packages/app/utils/coin-gecko/index.native.tsx
@@ -1,0 +1,1 @@
+export * from './index'

--- a/packages/app/utils/useTokenPrices.ts
+++ b/packages/app/utils/useTokenPrices.ts
@@ -72,7 +72,7 @@ const normalizeCoingeckoPrices = (prices: z.infer<typeof CoingeckoTokenPricesSch
   )
 }
 
-const fetchDexScreenerPrices = async () => {
+export const fetchDexScreenerPrices = async () => {
   // hardcoded to avoid testnet tokens
   const tokensToFetch = [
     '0x4200000000000000000000000000000000000006', // WETH

--- a/packages/ui/src/components/AnimatedCharts/charts/linear/ChartDot.web.tsx
+++ b/packages/ui/src/components/AnimatedCharts/charts/linear/ChartDot.web.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+// Web fallback: no-op ChartDot (avoid Reanimated worklets).
+const ChartDot = () => null
+export default ChartDot

--- a/packages/ui/src/components/AnimatedCharts/charts/linear/ChartPath.web.tsx
+++ b/packages/ui/src/components/AnimatedCharts/charts/linear/ChartPath.web.tsx
@@ -1,0 +1,290 @@
+import React, { useCallback, useMemo, useRef } from 'react'
+import { View } from 'react-native'
+import type { StyleProp, ViewStyle } from 'react-native'
+import Svg, { Path, type PathProps } from 'react-native-svg'
+import { useChartData } from '../../helpers/useChartData'
+
+// Web fallback for ChartPath without Reanimated worklets.
+// Implements pointer-based scrubbing using regular React events.
+
+type ChartPathWebProps = PathProps & {
+  width: number
+  height: number
+  stroke?: string
+  strokeWidth?: number
+  selectedStrokeWidth?: number
+  // Native-only prop passed by callers; ignore on web to avoid DOM warnings
+  panGestureHandlerProps?: unknown
+  gestureEnabled?: boolean
+  onScrub?: (payload: { active: boolean; ox?: number; oy?: number }) => void
+}
+
+function least(length: number, compare: (value: number) => number) {
+  let bound1 = 0
+  let bound2 = length - 1
+  while (true) {
+    const pivot = Math.round(bound1 + (bound2 - bound1) / 2)
+    if (bound1 === bound2) return bound1
+    const areTwoLeft = bound2 === bound1 + 1
+    if (compare(pivot - 1) - compare(pivot) > 0) {
+      if (areTwoLeft) return pivot
+      bound1 = pivot
+    } else {
+      bound2 = pivot
+      if (areTwoLeft) return pivot - 1
+    }
+  }
+}
+
+function getYForXFromPoints(points: { x: number; y: number }[], x: number): number | null {
+  if (!points || points.length === 0) return null
+  const first = points[0]
+  if (!first) return null
+  if (x <= first.x) return first.y
+  const last = points[points.length - 1]
+  if (!last) return null
+  if (x >= last.x) return last.y
+  for (let i = 0; i < points.length - 1; i++) {
+    const p1 = points[i]
+    const p2 = points[i + 1]
+    if (!p1 || !p2) continue
+    if (x === p1.x) return p1.y
+    if (x > p1.x && x <= p2.x) {
+      const t = (x - p1.x) / (p2.x - p1.x)
+      return p1.y + t * (p2.y - p1.y)
+    }
+  }
+  return null
+}
+
+export const ChartPath = React.memo(
+  ({
+    width,
+    height,
+    stroke = 'black',
+    strokeWidth = 1,
+    selectedStrokeWidth: _ignoreSelectedStrokeWidth,
+    panGestureHandlerProps: _ignorePanGestureHandlerProps,
+    gestureEnabled = true,
+    onScrub,
+    ...rest
+  }: ChartPathWebProps) => {
+    const {
+      currentPath,
+      originalX,
+      originalY,
+      isActive,
+      positionX,
+      positionY,
+      stroke: ctxStroke,
+      width: chartPathWidth,
+    } = useChartData()
+
+    const containerRef = useRef<View | null>(null)
+    const startXRef = useRef<number | null>(null)
+    const startYRef = useRef<number | null>(null)
+
+    const resetGestureState = useCallback(() => {
+      originalX.value = ''
+      originalY.value = ''
+      positionY.value = -1
+      isActive.value = false
+    }, [originalX, originalY, positionY, isActive])
+
+    const updatePosition = useCallback(
+      (x: number, y: number) => {
+        const path = currentPath
+        if (!path || path.points.length === 0) return
+
+        const clampedX = Math.max(0, Math.min(x, chartPathWidth))
+        const yForX = getYForXFromPoints(path.points, clampedX)
+        if (yForX !== null) {
+          positionY.value = yForX
+        }
+        positionX.value = clampedX
+
+        const index = least(path.points.length, (i) => {
+          const p = path.points[i]
+          return Math.abs((p ? p.x : 0) - clampedX)
+        })
+
+        const idx = Math.max(0, Math.min(index, path.points.length - 1))
+        const basePoint = path.points[idx]
+        const pointX = basePoint ? basePoint.originalX : (path.data[0]?.x ?? 0)
+
+        let adjustedPointX = pointX
+        const cur = path.points[idx]
+        const prev = path.points[idx - 1]
+        const next = path.points[idx + 1]
+        if (cur && cur.x > clampedX && prev) {
+          const denom = cur.x - prev.x
+          if (denom !== 0) {
+            const t = (cur.x - clampedX) / denom
+            adjustedPointX = prev.originalX * t + pointX * (1 - t)
+          }
+        } else if (cur && next) {
+          const denom = next.x - cur.x
+          if (denom !== 0) {
+            const t = (clampedX - cur.x) / denom
+            adjustedPointX = next.originalX * t + pointX * (1 - t)
+          }
+        }
+
+        const dataIndex = least(path.data.length, (i) => {
+          const d = path.data[i]
+          return Math.abs((d ? d.x : 0) - adjustedPointX)
+        })
+        const safeIndex = Math.max(0, Math.min(dataIndex, path.data.length - 1))
+        const d = path.data[safeIndex]
+        if (d) {
+          originalX.value = d.x.toString()
+          originalY.value = d.y.toString()
+          if (onScrub) {
+            onScrub({ active: true, ox: d.x, oy: d.y })
+          }
+        }
+      },
+      [currentPath, positionX, positionY, originalX, originalY, chartPathWidth, onScrub]
+    )
+
+    const handlePointerDown = useCallback(
+      (e: unknown) => {
+        if (!gestureEnabled) return
+        const evt = e as {
+          clientX?: number
+          clientY?: number
+          currentTarget?: { getBoundingClientRect: () => DOMRect }
+        }
+        const target = evt.currentTarget as unknown as HTMLElement
+        const rect = target.getBoundingClientRect()
+        const cx = typeof evt.clientX === 'number' ? evt.clientX : undefined
+        const cy = typeof evt.clientY === 'number' ? evt.clientY : undefined
+        if (typeof cx !== 'number' || typeof cy !== 'number') return
+        startXRef.current = cx - rect.left
+        startYRef.current = cy - rect.top
+      },
+      [gestureEnabled]
+    )
+
+    const handleMove = useCallback(
+      (e: unknown) => {
+        if (!gestureEnabled) return
+        if (!currentPath) return
+        const evt = e as {
+          clientX?: number
+          clientY?: number
+          currentTarget?: { getBoundingClientRect: () => DOMRect }
+          preventDefault?: () => void
+          nativeEvent?: {
+            pageX?: number
+            pageY?: number
+            touches?: Array<{ clientX?: number; clientY?: number; pageX?: number; pageY?: number }>
+          }
+          touches?: Array<{ clientX?: number; clientY?: number }>
+        }
+        const target = evt.currentTarget as unknown as HTMLElement
+        const rect = target.getBoundingClientRect()
+        let clientX: number | undefined
+        let clientY: number | undefined
+        if (typeof evt.clientX === 'number' && typeof evt.clientY === 'number') {
+          clientX = evt.clientX
+          clientY = evt.clientY
+        } else if (
+          evt?.nativeEvent &&
+          typeof evt.nativeEvent.pageX === 'number' &&
+          typeof evt.nativeEvent.pageY === 'number'
+        ) {
+          clientX = evt.nativeEvent.pageX
+          clientY = evt.nativeEvent.pageY
+        } else if (
+          evt?.nativeEvent &&
+          Array.isArray(evt.nativeEvent.touches) &&
+          evt.nativeEvent.touches[0]
+        ) {
+          const t = evt.nativeEvent.touches[0]
+          clientX = (typeof t.clientX === 'number' ? t.clientX : t.pageX) ?? undefined
+          clientY = (typeof t.clientY === 'number' ? t.clientY : t.pageY) ?? undefined
+        } else if (Array.isArray(evt.touches) && evt.touches[0]) {
+          const t = evt.touches[0]
+          clientX = t.clientX
+          clientY = t.clientY
+        }
+        if (typeof clientX !== 'number' || typeof clientY !== 'number') {
+          return
+        }
+        const x = clientX - rect.left
+        const y = clientY - rect.top
+        if (x < 0 || y < 0 || x > width || y > height) {
+          return
+        }
+        // Determine intent: allow vertical scroll if vertical movement dominates.
+        const sx = startXRef.current
+        const sy = startYRef.current
+        if (!isActive.value) {
+          if (sx == null || sy == null) {
+            startXRef.current = x
+            startYRef.current = y
+            return
+          }
+          const dx = Math.abs(x - sx)
+          const dy = Math.abs(y - sy)
+          if (dy > dx && dy > 8) {
+            // vertical intent: let page scroll
+            return
+          }
+          if (dx >= 8 && dx >= dy) {
+            isActive.value = true
+          } else {
+            return
+          }
+        }
+        if (typeof evt.preventDefault === 'function') evt.preventDefault()
+        updatePosition(x, y)
+      },
+      [gestureEnabled, currentPath, isActive, updatePosition, width, height]
+    )
+
+    const handleLeave = useCallback(() => {
+      resetGestureState()
+      startXRef.current = null
+      startYRef.current = null
+      if (onScrub) onScrub({ active: false })
+    }, [resetGestureState, onScrub])
+
+    const pathD = useMemo(() => currentPath?.path ?? '', [currentPath?.path])
+    const finalStroke = stroke ?? ctxStroke
+
+    const pointerProps = {
+      onPointerDown: handlePointerDown,
+      onPointerMove: handleMove,
+      onPointerUp: handleLeave,
+      onPointerCancel: handleLeave,
+      onPointerLeave: handleLeave,
+    } as const
+
+    return (
+      <View
+        style={[
+          { height, width },
+          [{ touchAction: 'pan-y' } as unknown as ViewStyle] as unknown as StyleProp<ViewStyle>,
+        ]}
+        ref={containerRef}
+        {...(pointerProps as unknown as React.ComponentProps<typeof View>)}
+      >
+        {pathD ? (
+          <Svg style={{ height, width }} viewBox={`0 0 ${width} ${height}`}>
+            <Path
+              d={pathD}
+              stroke={finalStroke}
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+              fill="none"
+              {...rest}
+            />
+          </Svg>
+        ) : null}
+      </View>
+    )
+  }
+)
+ChartPath.displayName = 'ChartPath'


### PR DESCRIPTION
### TL;DR

Refactored the token chart component to improve code organization and add web support for chart scrubbing.

### What changed?

- Restructured the token chart code by extracting reusable components into separate files
- Created platform-specific implementations for chart scrubbing (native and web)
- Added web-specific implementations for `ChartPath` and `ChartDot` components
- Improved chart styling and layout consistency across platforms
- Added gesture handling for web to enable chart scrubbing without Reanimated worklets
- Imported required gesture handler and reanimated packages in Next.js app
- Extracted timeframe utilities into a shared module

### How to test?

1. Run the app on both web and native platforms
2. Navigate to a token detail page with a price chart
3. Test chart scrubbing on both platforms:
    - On native: Use long press and drag to scrub through the chart
    - On web: Use mouse or touch to scrub through the chart
4. Verify that timeframe selection works (1D, 1W, 1M, etc.)
5. Check that price and timestamp information updates correctly during scrubbing

### Why make this change?

The previous implementation lacked proper web support for chart scrubbing and had all chart-related code in a single file. This refactoring improves code organization by separating concerns into smaller, more focused components. It also adds proper web support for chart interactions without relying on React Native Reanimated worklets, which don't work well on the web platform. The changes make the chart component more maintainable and provide a consistent user experience across platforms.