### PR TITLE
Native: fixed issue with disappearing elevation on android while scrolling

### DIFF
--- a/apps/expo/components/layout/ScreenContainer.tsx
+++ b/apps/expo/components/layout/ScreenContainer.tsx
@@ -25,7 +25,7 @@ export const ScreenContainer = ({ children }: PropsWithChildren) => {
         showsVerticalScrollIndicator={false}
         overflow={'visible'}
         bounces={true}
-        overScrollMode="always" // Android scroll indicator
+        overScrollMode="never" // Android scroll indicator
       >
         {children}
       </ScrollView>

--- a/apps/expo/components/layout/TabScreenContainer.tsx
+++ b/apps/expo/components/layout/TabScreenContainer.tsx
@@ -27,7 +27,7 @@ export const TabScreenContainer = ({ children }: PropsWithChildren) => {
         showsVerticalScrollIndicator={false}
         scrollEventThrottle={128}
         bounces={true}
-        overScrollMode="always" // Android scroll indicator
+        overScrollMode="never" // Android scroll indicator
         overflow={'visible'}
         onScroll={(e) => {
           if (isFocused) {

--- a/packages/app/components/SearchBar.tsx
+++ b/packages/app/components/SearchBar.tsx
@@ -122,6 +122,7 @@ function SearchResults() {
       }}
       showsVerticalScrollIndicator={false}
       overflow="visible"
+      overScrollMode={'never'}
       {...(Platform.OS === 'web'
         ? {}
         : {

--- a/packages/app/features/activity/RecentActivityFeed.native.tsx
+++ b/packages/app/features/activity/RecentActivityFeed.native.tsx
@@ -202,6 +202,7 @@ export default function ActivityFeed({
         layoutProvider={layoutProvider}
         scrollViewProps={{
           showsVerticalScrollIndicator: false,
+          overScrollMode: 'never',
         }}
         onContentSizeChange={onContentSizeChange}
         onScroll={(e) => {

--- a/packages/app/features/affiliate/screen.native.tsx
+++ b/packages/app/features/affiliate/screen.native.tsx
@@ -81,6 +81,7 @@ export default function FriendsScreen() {
         layoutProvider={layoutProvider}
         scrollViewProps={{
           showsVerticalScrollIndicator: false,
+          overScrollMode: 'never',
         }}
         onEndReached={handleEndReach}
         onEndReachedThreshold={0.5}

--- a/packages/app/features/earn/earnings/screen.tsx
+++ b/packages/app/features/earn/earnings/screen.tsx
@@ -11,14 +11,12 @@ import { useEarnActivityFeed } from '../utils/useEarnActivityFeed'
 
 export const EarningsBalance = () => {
   return (
-    <YStack
-      w={'100%'}
-      gap={'$4'}
-      pb={'$3'}
-      $gtLg={{ w: '50%' }}
-      elevation={Platform.OS === 'web' ? 0 : '$0.75'}
-    >
-      <ScrollView showsVerticalScrollIndicator={false} overflow={'visible'}>
+    <YStack w={'100%'} gap={'$4'} pb={'$3'} $gtLg={{ w: '50%' }}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        overflow={'visible'}
+        overScrollMode={'never'}
+      >
         <YStack gap={'$4'}>
           <TotalEarning />
           <Paragraph size={'$7'} fontWeight={'600'}>
@@ -205,13 +203,7 @@ function TotalEarning() {
 
   return (
     <Fade>
-      <Card
-        w={'100%'}
-        p={'$5'}
-        gap={'$7'}
-        elevation={Platform.OS === 'web' ? '$0.75' : 0}
-        $gtLg={{ p: '$7' }}
-      >
+      <Card w={'100%'} p={'$5'} gap={'$7'} $gtLg={{ p: '$7' }}>
         <YStack gap={'$3.5'}>
           <XStack ai={'center'} gap={'$2'}>
             <IconCoin symbol={coin.data.symbol} size={'$2'} />

--- a/packages/app/features/earn/rewards/screen.tsx
+++ b/packages/app/features/earn/rewards/screen.tsx
@@ -185,9 +185,12 @@ function RewardsBalance() {
       pb={'$3'}
       f={Platform.OS === 'web' ? undefined : 1}
       $gtLg={{ w: '50%' }}
-      elevation={Platform.OS === 'web' ? 0 : '$0.75'}
     >
-      <ScrollView showsVerticalScrollIndicator={false} overflow={'visible'}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        overflow={'visible'}
+        overScrollMode={'never'}
+      >
         <YStack gap={'$4'}>
           <TotalRewards
             rewards={formattedRewards}
@@ -374,13 +377,7 @@ const TotalRewards = ({ rewards, isLoading, coin }: TotalRewardsProps = {}) => {
 
   return (
     <Fade>
-      <Card
-        w={'100%'}
-        p={'$5'}
-        gap={'$7'}
-        elevation={Platform.OS === 'web' ? '$0.75' : 0}
-        $gtLg={{ p: '$7' }}
-      >
+      <Card w={'100%'} p={'$5'} gap={'$7'} $gtLg={{ p: '$7' }}>
         <YStack gap={'$4'}>
           <XStack ai={'center'} gap={'$2'}>
             <IconCoin symbol={coin?.symbol || ''} size={'$2'} />

--- a/packages/app/features/home/TokenActivityFeed.native.tsx
+++ b/packages/app/features/home/TokenActivityFeed.native.tsx
@@ -196,6 +196,7 @@ export default function TokenActivityFeed({
         layoutProvider={layoutProvider}
         scrollViewProps={{
           showsVerticalScrollIndicator: false,
+          overScrollMode: 'never',
         }}
         onEndReached={handleEndReach}
         onEndReachedThreshold={0.5}

--- a/packages/app/features/send-token-upgrade/screen.tsx
+++ b/packages/app/features/send-token-upgrade/screen.tsx
@@ -101,6 +101,7 @@ export function SendV0TokenUpgradeScreen({ children }: { children?: React.ReactN
       w="100%"
       maw="100%"
       mih={600}
+      overScrollMode={'never'}
       f={1}
     >
       <IconSendLogo size="$8" color="$color12" mx="auto" />

--- a/packages/app/features/send/confirm/screen.tsx
+++ b/packages/app/features/send/confirm/screen.tsx
@@ -504,7 +504,7 @@ function ErrorMessage({ error, ...props }: ParagraphProps & { error?: string }) 
   if (!error) return null
 
   return (
-    <ScrollView height="$4">
+    <ScrollView height="$4" overScrollMode={'never'}>
       <Paragraph testID="SendConfirmError" size="$2" width="100%" col={'$error'} {...props}>
         {error.split('.').at(0)}
       </Paragraph>

--- a/packages/ui/src/components/FormWrapper.native.tsx
+++ b/packages/ui/src/components/FormWrapper.native.tsx
@@ -56,7 +56,7 @@ const Wrapper = forwardRef<TamaguiElement, YStackProps>(function Wrapper(props, 
 
 const Body = forwardRef<TamaguiElement, YStackProps>(function Body(props, ref) {
   return (
-    <ScrollView>
+    <ScrollView overScrollMode={'never'}>
       <YStack p="$4" ref={ref} gap="$2" pb="$8" {...props} />
     </ScrollView>
   )


### PR DESCRIPTION
## Summary 

Fixed issue with disappearing elevation on Android while scrolling by setting overScrollMode to 'never' in various ScrollView components.


## Changes Made

- Fixed elevation issue on Android
- Updated overScrollMode in ScrollView components
- Removed elevation from Card components

_written by Kolwaii, your beloved blockchain engineer AI agent_