### PR TITLE
Native: fixed some weird random gaps between activity rows on android

### DIFF
--- a/packages/app/features/activity/RecentActivityFeed.native.tsx
+++ b/packages/app/features/activity/RecentActivityFeed.native.tsx
@@ -143,6 +143,8 @@ export default function ActivityFeed({
           return (
             <XStack
               backgroundColor={'$color1'}
+              borderWidth={1}
+              borderColor={'$color1'}
               borderTopLeftRadius={item.isFirstInGroup ? '$6' : 0}
               borderTopRightRadius={item.isFirstInGroup ? '$6' : 0}
               borderBottomLeftRadius={item.isLastInGroup ? '$6' : 0}

--- a/packages/app/features/home/TokenActivityFeed.native.tsx
+++ b/packages/app/features/home/TokenActivityFeed.native.tsx
@@ -163,6 +163,8 @@ export default function TokenActivityFeed({
           return (
             <XStack
               backgroundColor={'$color1'}
+              borderWidth={1}
+              borderColor={'$color1'}
               borderTopLeftRadius={isFirst ? '$6' : 0}
               borderTopRightRadius={isFirst ? '$6' : 0}
               borderBottomLeftRadius={isLast ? '$6' : 0}

--- a/packages/app/features/home/TokenActivityRow.tsx
+++ b/packages/app/features/home/TokenActivityRow.tsx
@@ -71,6 +71,8 @@ export function TokenActivityRow({
       gap="$4"
       p="$3.5"
       br={'$4'}
+      borderWidth={1}
+      borderColor={'$color1'}
       cursor={onPress ? 'pointer' : 'default'}
       testID={'TokenActivityRow'}
       hoverStyle={onPress ? hoverStyles : null}


### PR DESCRIPTION
## Summary 

Fixed random gaps between activity rows on Android by adding border width and color.


## Changes Made

- Added border width and color to XStack components
- Updated TokenActivityRow with border width and color

_written by Kolwaii, your beloved blockchain engineer AI agent_