### PR TITLE
Charts: require 500ms hold to scrub

### DIFF
--- a/apps/expo/components/layout/ScreenContainer.tsx
+++ b/apps/expo/components/layout/ScreenContainer.tsx
@@ -1,9 +1,12 @@
 import { Container, ScrollView, useSafeAreaInsets } from '@my/ui'
 import type { PropsWithChildren } from 'react'
+import { Gesture, GestureDetector } from 'react-native-gesture-handler'
+import { ScrollGestureProvider } from '@my/ui/src/gestures/ScrollGestureContext'
 
 export const CONTAINER_OFFSET = 10
 
 export const ScreenContainer = ({ children }: PropsWithChildren) => {
+  const native = Gesture.Native()
   const insets = useSafeAreaInsets()
 
   return (
@@ -15,20 +18,24 @@ export const ScreenContainer = ({ children }: PropsWithChildren) => {
       flex={1}
       backgroundColor="$background"
     >
-      <ScrollView
-        flex={1}
-        contentContainerStyle={{
-          flexGrow: 1,
-          paddingTop: CONTAINER_OFFSET,
-          paddingBottom: CONTAINER_OFFSET + insets.bottom,
-        }}
-        showsVerticalScrollIndicator={false}
-        overflow={'visible'}
-        bounces={true}
-        overScrollMode="never" // Android scroll indicator
-      >
-        {children}
-      </ScrollView>
+      <ScrollGestureProvider value={native}>
+        <GestureDetector gesture={native}>
+          <ScrollView
+            flex={1}
+            contentContainerStyle={{
+              flexGrow: 1,
+              paddingTop: CONTAINER_OFFSET,
+              paddingBottom: CONTAINER_OFFSET + insets.bottom,
+            }}
+            showsVerticalScrollIndicator={false}
+            overflow={'visible'}
+            bounces={true}
+            overScrollMode="never" // Android scroll indicator
+          >
+            {children}
+          </ScrollView>
+        </GestureDetector>
+      </ScrollGestureProvider>
     </Container>
   )
 }

--- a/packages/app/features/home/charts/shared/components/ChartLineSection.tsx
+++ b/packages/app/features/home/charts/shared/components/ChartLineSection.tsx
@@ -1,6 +1,6 @@
-import { ChartPathProvider, ChartPath, ChartDot } from '@my/ui'
+import { ChartPathProvider, ChartPath, ChartDot, View } from '@my/ui'
 import { useMemo } from 'react'
-import { View } from 'react-native'
+import { useScrollNativeGesture } from '@my/ui/src/gestures/ScrollGestureContext'
 
 export function ChartLineSection({
   points,
@@ -27,8 +27,22 @@ export function ChartLineSection({
     [points, smoothed]
   )
 
+  const native = useScrollNativeGesture()
+
+  const gesturePad = 24
+  const { onScrub, ...restPathProps } = (pathProps ?? {}) as {
+    onScrub?: (payload: { active: boolean; ox?: number; oy?: number }) => void
+  } & Record<string, unknown>
+
+  const mergedPanProps = {
+    shouldCancelWhenOutside: false,
+    hitSlop: { top: gesturePad, bottom: gesturePad },
+    nativeScrollGesture: native ?? undefined,
+    ...restPathProps,
+  } as never
+
   return (
-    <View style={{ width }}>
+    <View w={width}>
       <ChartPathProvider
         data={data}
         width={width}
@@ -40,15 +54,15 @@ export function ChartLineSection({
         {/* Scrub readout in normal flow above the chart */}
         {childrenBeforePath}
         {/* Fixed-height chart area below */}
-        <View style={{ height: H, width }}>
+        <View h={H} w={width}>
           <ChartPath
             width={width}
             height={H}
             stroke={stroke}
             fill="none"
-            selectedStrokeWidth={3}
+            selectedStrokeWidth={5}
             strokeWidth={3.5}
-            panGestureHandlerProps={pathProps as never}
+            panGestureHandlerProps={mergedPanProps}
             onScrub={
               typeof pathProps?.onScrub === 'function'
                 ? (pathProps.onScrub as (payload: {

--- a/packages/ui/src/gestures/ScrollGestureContext.tsx
+++ b/packages/ui/src/gestures/ScrollGestureContext.tsx
@@ -1,0 +1,21 @@
+import type React from 'react'
+import { createContext, useContext } from 'react'
+import type { Gesture } from 'react-native-gesture-handler'
+
+export type NativeGestureType = ReturnType<typeof Gesture.Native>
+
+const ScrollGestureContext = createContext<NativeGestureType | null>(null)
+
+export function ScrollGestureProvider({
+  value,
+  children,
+}: {
+  value: NativeGestureType
+  children: React.ReactNode
+}) {
+  return <ScrollGestureContext.Provider value={value}>{children}</ScrollGestureContext.Provider>
+}
+
+export function useScrollNativeGesture(): NativeGestureType | null {
+  return useContext(ScrollGestureContext)
+}


### PR DESCRIPTION
Why:
Vertical page scroll was being intercepted when the initial touch
started on the chart. Requiring a 500ms hold before activating chart
scrubbing lets normal vertical scrolling pass through while still
allowing deliberate chart interactions. Web adds a subtle focused
indicator (stroke width bump) during active scrubbing; native keeps the
existing focus animation. Behavior is gated on both platforms and
resets on end/cancel.

References:
- packages/ui/src/components/AnimatedCharts/charts/linear/ChartPath.web.tsx
  (pointer-event gating with touch-action: pan-y, preventDefault only
  when active)
- packages/ui/src/components/PendingIndicatorBar.tsx
  (setTimeout/clearTimeout lifecycle pattern used for reliable timers)
- packages/ui/src/components/AnimatedCharts/charts/linear/ChartPath.tsx
  (native: runOnJS + setTimeout hold gate before scrubbing)

Test plan:
Web:
- On a touch device/emulator, drag vertically starting on the chart:
  page scroll should pass through; scrubbing should NOT start.
- Press and hold ~500ms on the chart, then move horizontally:
  scrubbing starts; extremes labels hide; release cancels.
- Mouse: press-hold ~500ms then scrub; release resets; focused indicator
  only while active.

Native (Expo iOS/Android):
- Vertical scroll starting on the chart passes through until ~500ms hold
  is recognized; after hold, horizontal pan scrubs values; release/cancel
  resets; haptics/animations unchanged.