### PR TITLE
refactor: extract percent change util + tests

### DIFF
--- a/packages/app/features/home/InvestmentsBalanceCard.tsx
+++ b/packages/app/features/home/InvestmentsBalanceCard.tsx
@@ -14,7 +14,7 @@ import {
   type ButtonProps,
   Button,
 } from '@my/ui'
-import formatAmount from 'app/utils/formatAmount'
+import formatAmount, { localizeAmount } from 'app/utils/formatAmount'
 import { ChevronLeft, ChevronRight } from '@tamagui/lucide-icons'
 import { useIsPriceHidden } from './utils/useIsPriceHidden'
 import { useSendAccountBalances } from 'app/utils/useSendAccountBalances'
@@ -29,6 +29,7 @@ import { useMemo } from 'react'
 import { IconCoin, IconError } from 'app/components/icons'
 import { useCoins } from 'app/provider/coins'
 import { formatUnits } from 'viem'
+import { calculatePercentageChange } from './utils/calculatePercentageChange'
 import { HomeBodyCard } from './screen'
 import { Platform } from 'react-native'
 import { useRouter } from 'solito/router'
@@ -333,9 +334,7 @@ function InvestmentsWeeklyDelta() {
           ? md.price_change_percentage_7d_in_currency
           : 0) ?? 0
 
-      // Calculate the actual dollar change from 7 days ago to now
-      const previousValue = value / (1 + pct7d / 100)
-      const actualChange = value - previousValue
+      const actualChange = calculatePercentageChange(value, pct7d)
 
       return sum + actualChange
     }, 0)
@@ -361,9 +360,10 @@ function InvestmentsWeeklyDelta() {
     )
 
   const sign = deltaUSD >= 0 ? '+' : '-'
+  const formattedDeltaUSD = localizeAmount(Math.abs(deltaUSD).toFixed(2))
   return (
     <Paragraph color={'$color10'} fontWeight={400} size={'$5'}>
-      {`${sign}$${Math.abs(deltaUSD).toFixed(2)} this week`}
+      {`${sign}$${formattedDeltaUSD} this week`}
     </Paragraph>
   )
 }

--- a/packages/app/features/home/TokenDetailsHeader.tsx
+++ b/packages/app/features/home/TokenDetailsHeader.tsx
@@ -3,12 +3,13 @@ import { IconCoin } from 'app/components/icons'
 import { type CoinWithBalance, stableCoins } from 'app/data/coins'
 import { useTokensMarketData } from 'app/utils/coin-gecko'
 import { convertBalanceToFiat } from 'app/utils/convertBalanceToUSD'
-import formatAmount from 'app/utils/formatAmount'
+import formatAmount, { localizeAmount } from 'app/utils/formatAmount'
 import { useTokenPrices } from 'app/utils/useTokenPrices'
 import { useMemo } from 'react'
 import { Platform } from 'react-native'
 import { TokenQuickActions } from './TokenQuickActions'
 import { useCoinFromTokenParam } from 'app/utils/useCoinFromTokenParam'
+import { calculatePercentageChange } from './utils/calculatePercentageChange'
 
 export const TokenDetailsHeader = () => {
   const { coin } = useCoinFromTokenParam()
@@ -136,12 +137,9 @@ const TokenDetailsBalance = ({
 
   // Compute the main USD balance and the USD delta for today
   const mainUSDBalance = balanceInUSD ?? 0
-  let usdDelta = 0
-  if (changePercent24h !== null && mainUSDBalance) {
-    // Calculate the actual dollar change from 24h ago to now
-    const previousValue = mainUSDBalance / (1 + changePercent24h / 100)
-    usdDelta = mainUSDBalance - previousValue
-  }
+  const usdDelta = calculatePercentageChange(mainUSDBalance, changePercent24h)
+  const formattedDeltaUSD = localizeAmount(Math.abs(usdDelta).toFixed(2))
+  const sign = usdDelta >= 0 ? '+' : '-'
 
   const changeBadge = (() => {
     if (changePercent24h === null || coin?.balance === 0n) return null
@@ -209,7 +207,7 @@ const TokenDetailsBalance = ({
       {/* USD delta under main balance */}
       {!isStableCoin && !isLoadingMarketData && changePercent24h !== null ? (
         <Paragraph color={'$color10'} fontWeight={'400'} size={'$5'}>
-          {`${usdDelta >= 0 ? '+' : '-'}$${formatAmount(Math.abs(usdDelta), 9, 2)} today`}
+          {`${sign}$${formattedDeltaUSD} today`}
         </Paragraph>
       ) : null}
     </YStack>

--- a/packages/app/features/home/screen.tsx
+++ b/packages/app/features/home/screen.tsx
@@ -40,6 +40,8 @@ import { Platform } from 'react-native'
 import { usePathname } from 'app/utils/usePathname'
 import { useTokensMarketData } from 'app/utils/coin-gecko'
 import { formatUnits } from 'viem'
+import { calculatePercentageChange } from './utils/calculatePercentageChange'
+import { localizeAmount } from 'app/utils/formatAmount'
 
 export function HomeScreen() {
   const media = useMedia()
@@ -193,9 +195,7 @@ export function InvestmentsBody() {
 
     const total = assets.reduce((s, a) => s + a.value, 0)
     const delta = assets.reduce((s, a) => {
-      // Calculate the actual dollar change from 24h ago to now
-      const previousValue = a.value / (1 + a.pct24h / 100)
-      const actualChange = a.value - previousValue
+      const actualChange = calculatePercentageChange(a.value, a.pct24h)
       return s + actualChange
     }, 0)
     const weightedPct =
@@ -208,6 +208,9 @@ export function InvestmentsBody() {
       setIsSheetOpen(false)
     }
   }, [pathname])
+
+  const formattedDeltaUSD = localizeAmount(Math.abs(delta24hUSD).toFixed(2))
+  const sign = delta24hUSD >= 0 ? '+' : '-'
 
   return (
     <YStack ai="center" $gtXs={{ gap: '$3' }} gap={'$3.5'} f={1}>
@@ -246,7 +249,7 @@ export function InvestmentsBody() {
             ) : (
               <YStack ai={'center'} gap={'$2'}>
                 <Paragraph size={'$4'} fontWeight={600} color={'$color12'}>
-                  {`${delta24hUSD > 0 ? '+' : delta24hUSD < 0 ? '-' : ''}$${Math.abs(delta24hUSD).toFixed(2)}`}
+                  {`${sign}$${formattedDeltaUSD}`}
                 </Paragraph>
                 {/* Small neutral pill to mirror style (no color change) */}
                 <Theme name={pct24h >= 0 ? 'green_active' : 'red_active'}>

--- a/packages/app/features/home/utils/__tests__/calculatePercentageChange.test.ts
+++ b/packages/app/features/home/utils/__tests__/calculatePercentageChange.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from '@jest/globals'
+import { calculatePercentageChange } from '../calculatePercentageChange'
+
+describe('calculatePercentageChange', () => {
+  it('should return 0 when percentageChange is null', () => {
+    expect(calculatePercentageChange(100, null)).toBe(0)
+  })
+
+  it('should return 0 when currentValue is 0', () => {
+    expect(calculatePercentageChange(0, 50)).toBe(0)
+  })
+
+  it('should calculate correct change for positive percentage', () => {
+    // Previous value: 100 / (1 + 50/100) = 100 / 1.5 = 66.67
+    // Change: 100 - 66.67 = 33.33
+    expect(calculatePercentageChange(100, 50)).toBeCloseTo(33.33, 2)
+  })
+
+  it('should calculate correct change for negative percentage', () => {
+    // Previous value: 100 / (1 + (-50)/100) = 100 / 0.5 = 200
+    // Change: 100 - 200 = -100
+    expect(calculatePercentageChange(100, -50)).toBeCloseTo(-100, 2)
+  })
+
+  it('should handle percentage changes > 100% correctly', () => {
+    // Previous value: 100 / (1 + 150/100) = 100 / 2.5 = 40
+    // Change: 100 - 40 = 60
+    expect(calculatePercentageChange(100, 150)).toBeCloseTo(60, 2)
+  })
+
+  it('should handle percentage changes > 200% correctly', () => {
+    // Previous value: 100 / (1 + 300/100) = 100 / 4 = 25
+    // Change: 100 - 25 = 75
+    expect(calculatePercentageChange(100, 300)).toBeCloseTo(75, 2)
+  })
+
+  it('should handle very large percentage changes', () => {
+    // Previous value: 100 / (1 + 1000/100) = 100 / 11 = 9.09
+    // Change: 100 - 9.09 = 90.91
+    expect(calculatePercentageChange(100, 1000)).toBeCloseTo(90.91, 2)
+  })
+
+  it('should handle small percentage changes', () => {
+    // Previous value: 100 / (1 + 1/100) = 100 / 1.01 = 99.01
+    // Change: 100 - 99.01 = 0.99
+    expect(calculatePercentageChange(100, 1)).toBeCloseTo(0.99, 2)
+  })
+
+  it('should handle zero percentage change', () => {
+    // Previous value: 100 / (1 + 0/100) = 100 / 1 = 100
+    // Change: 100 - 100 = 0
+    expect(calculatePercentageChange(100, 0)).toBe(0)
+  })
+
+  it('should handle decimal current values', () => {
+    // Previous value: 123.45 / (1 + 25/100) = 123.45 / 1.25 = 98.76
+    // Change: 123.45 - 98.76 = 24.69
+    expect(calculatePercentageChange(123.45, 25)).toBeCloseTo(24.69, 2)
+  })
+
+  it('should handle decimal percentage changes', () => {
+    // Previous value: 100 / (1 + 12.5/100) = 100 / 1.125 = 88.89
+    // Change: 100 - 88.89 = 11.11
+    expect(calculatePercentageChange(100, 12.5)).toBeCloseTo(11.11, 2)
+  })
+})
+
+describe('Edge cases and boundary conditions', () => {
+  it('should handle very small positive percentages', () => {
+    expect(calculatePercentageChange(100, 0.01)).toBeCloseTo(0.01, 4)
+  })
+
+  it('should handle very small negative percentages', () => {
+    expect(calculatePercentageChange(100, -0.01)).toBeCloseTo(-0.01, 4)
+  })
+
+  it('should handle very large current values', () => {
+    expect(calculatePercentageChange(1000000, 50)).toBeCloseTo(333333.33, 2)
+  })
+
+  it('should handle very small current values', () => {
+    expect(calculatePercentageChange(0.01, 50)).toBeCloseTo(0.0033, 4)
+  })
+
+  it('should handle extreme negative percentages', () => {
+    // Previous value: 100 / (1 + (-99)/100) = 100 / 0.01 = 10000
+    // Change: 100 - 10000 = -9900
+    expect(calculatePercentageChange(100, -99)).toBeCloseTo(-9900, 2)
+  })
+})

--- a/packages/app/features/home/utils/calculatePercentageChange.ts
+++ b/packages/app/features/home/utils/calculatePercentageChange.ts
@@ -1,0 +1,27 @@
+/**
+ * Utility function for calculating actual dollar changes from percentage changes
+ *
+ * This function correctly handles percentage changes > 100% by calculating
+ * the actual dollar change from the previous value to the current value,
+ * rather than applying the percentage to the current value.
+ *
+ * @param currentValue - The current USD value
+ * @param percentageChange - The percentage change (e.g., 50 for 50% increase)
+ * @returns The actual dollar change from the previous period to now
+ */
+export function calculatePercentageChange(
+  currentValue: number,
+  percentageChange: number | null
+): number {
+  if (percentageChange === null || currentValue === 0) {
+    return 0
+  }
+
+  // Calculate the actual dollar change from the previous period to now
+  // If percentageChange is positive, the previous value was: current_value / (1 + percentageChange/100)
+  // The change is: current_value - previous_value
+  const previousValue = currentValue / (1 + percentageChange / 100)
+  const actualChange = currentValue - previousValue
+
+  return actualChange
+}


### PR DESCRIPTION
Why:
Inline percentage-based USD delta calculations were duplicated and
error-prone. This refactor extracts a clear utility that computes the
actual dollar change using the previous-value method (previous =
current / (1 + pct/100)), and updates call sites to use it.

Changes:
- Extract calculatePercentageChange utility.
- Replace inline calculations in Home/Investments components.
- Add comprehensive unit tests covering positive/negative/edge cases.

Affected files:
- packages/app/features/home/InvestmentsBalanceCard.tsx
- packages/app/features/home/TokenDetailsHeader.tsx
- packages/app/features/home/screen.tsx
- packages/app/features/home/utils/__tests__/calculatePercentageChange.test.ts
- packages/app/features/home/utils/calculatePercentageChange.ts

Test plan:
- Run app tests:
  yarn workspace app test --watchAll=false --runInBand
- Expect: all test suites pass; no new warningsExpect: all test suites pass; no new warnings.