### PR TITLE
Native: added platform specific hooks for navigation

### DIFF
--- a/packages/app/utils/usePush.native.ts
+++ b/packages/app/utils/usePush.native.ts
@@ -1,0 +1,6 @@
+import { useRouter } from 'expo-router'
+
+export const usePush = () => {
+  const router = useRouter()
+  return router.push
+}

--- a/packages/app/utils/usePush.ts
+++ b/packages/app/utils/usePush.ts
@@ -1,0 +1,6 @@
+import { useRouter } from 'solito/router'
+
+export const usePush = () => {
+  const router = useRouter()
+  return router.push as (url: string) => void
+}

--- a/packages/app/utils/useReplace.native.ts
+++ b/packages/app/utils/useReplace.native.ts
@@ -1,0 +1,6 @@
+import { useRouter } from 'expo-router'
+
+export const useReplace = () => {
+  const router = useRouter()
+  return router.replace
+}

--- a/packages/app/utils/useReplace.ts
+++ b/packages/app/utils/useReplace.ts
@@ -1,0 +1,6 @@
+import { useRouter } from 'solito/router'
+
+export const useReplace = () => {
+  const router = useRouter()
+  return router.replace as (url: string) => void
+}


### PR DESCRIPTION
Added very simple platform specific hooks for navigation as solito is not doing great job at memoizing push and replace functions on native. Direct exports from expo-router are memoized by expo. 