### PR TITLE
Fixed double url in share

### DIFF
--- a/packages/app/features/account/components/AccountHeader.tsx
+++ b/packages/app/features/account/components/AccountHeader.tsx
@@ -42,7 +42,6 @@ export const AccountHeader = memo<YStackProps>(function AccountHeader(props) {
 
     void Share.share({
       message: referralHref,
-      url: referralHref,
     }).catch(() => null)
   }, [referralHref])
 


### PR DESCRIPTION
## Summary 

Fixed double URL in share functionality by removing redundant URL parameter.


## Changes Made

- Removed redundant URL parameter in share functionality

_written by Kolwaii, your beloved blockchain engineer AI agent_