### PR TITLE
Add is_verified to profile_lookup

### DIFF
--- a/supabase/database-generated.types.ts
+++ b/supabase/database-generated.types.ts
@@ -2222,6 +2222,7 @@ export type Database = {
           | Database["public"]["Tables"]["link_in_bio"]["Row"][]
           | null
         banner_url: string | null
+        is_verified: boolean | null
       }
       tag_search_result: {
         avatar_url: string | null

--- a/supabase/migrations/20250930143101_add_is_verified_to_profile_lookup.sql
+++ b/supabase/migrations/20250930143101_add_is_verified_to_profile_lookup.sql
@@ -1,0 +1,138 @@
+drop view if exists "public"."referrer";
+
+set check_function_bodies = off;
+
+alter type "public"."profile_lookup_result" add attribute "is_verified" boolean;
+
+CREATE OR REPLACE FUNCTION public.profile_lookup(lookup_type lookup_type_enum, identifier text)
+ RETURNS SETOF profile_lookup_result
+ LANGUAGE plpgsql
+ IMMUTABLE SECURITY DEFINER
+AS $function$
+begin
+    if identifier is null or identifier = '' then raise exception 'identifier cannot be null or empty'; end if;
+    if lookup_type is null then raise exception 'lookup_type cannot be null'; end if;
+
+    RETURN QUERY
+    WITH current_distribution_id AS (
+        SELECT id FROM distributions
+        WHERE qualification_start <= CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+          AND qualification_end >= CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+        ORDER BY qualification_start DESC
+        LIMIT 1
+    )
+    SELECT
+        case when p.id = ( select auth.uid() ) then p.id end,
+        p.avatar_url::text,
+        p.name::text,
+        p.about::text,
+        p.referral_code,
+        CASE WHEN p.is_public THEN p.x_username ELSE NULL END,
+        CASE WHEN p.is_public THEN p.birthday ELSE NULL END,
+        COALESCE(mt.name, t.name),
+        sa.address,
+        sa.chain_id,
+        case when current_setting('role')::text = 'service_role' then p.is_public
+            when p.is_public then true
+            else false end,
+        p.send_id,
+        ( select array_agg(t2.name::text)
+          from tags t2
+          join send_account_tags sat2 on sat2.tag_id = t2.id
+          join send_accounts sa2 on sa2.id = sat2.send_account_id
+          where sa2.user_id = p.id and t2.status = 'confirmed'::tag_status ),
+        case when p.id = ( select auth.uid() ) then sa.main_tag_id end,
+        mt.name::text,
+        CASE WHEN p.is_public THEN
+(SELECT array_agg(link_in_bio_row)
+            FROM (
+                SELECT ROW(
+                    CASE WHEN lib.user_id = (SELECT auth.uid()) THEN lib.id ELSE NULL END,
+                    CASE WHEN lib.user_id = (SELECT auth.uid()) THEN lib.user_id ELSE NULL END,
+                    lib.handle,
+                    lib.domain_name,
+                    lib.created_at,
+                    lib.updated_at,
+                    lib.domain
+                )::link_in_bio as link_in_bio_row
+                FROM link_in_bio lib
+                WHERE lib.user_id = p.id AND lib.handle IS NOT NULL
+            ) sub)
+        ELSE NULL
+        END,
+        p.banner_url::text,
+        CASE WHEN ds.user_id IS NOT NULL THEN true ELSE false END AS is_verified
+    from profiles p
+    join auth.users a on a.id = p.id
+    left join send_accounts sa on sa.user_id = p.id
+    left join tags mt on mt.id = sa.main_tag_id
+    left join send_account_tags sat on sat.send_account_id = sa.id
+    left join tags t on t.id = sat.tag_id and t.status = 'confirmed'::tag_status
+    left join distribution_shares ds on ds.user_id = p.id
+        and ds.distribution_id = (select id from current_distribution_id)
+    where ((lookup_type = 'sendid' and p.send_id::text = identifier) or
+        (lookup_type = 'tag' and t.name = identifier::citext) or
+        (lookup_type = 'refcode' and p.referral_code = identifier) or
+        (lookup_type = 'address' and sa.address = identifier) or
+        (p.is_public and lookup_type = 'phone' and a.phone::text = identifier))
+    and (p.is_public
+     or ( select auth.uid() ) is not null
+     or current_setting('role')::text = 'service_role')
+    limit 1;
+end;
+$function$
+;
+
+
+create or replace view "public"."referrer" as  WITH referrer AS (
+         SELECT p.send_id
+           FROM (referrals r
+             JOIN profiles p ON ((r.referrer_id = p.id)))
+          WHERE (r.referred_id = ( SELECT auth.uid() AS uid))
+          ORDER BY r.created_at
+         LIMIT 1
+        ), profile_lookup AS (
+         SELECT p.id,
+            p.avatar_url,
+            p.name,
+            p.about,
+            p.refcode,
+            p.x_username,
+            p.birthday,
+            p.tag,
+            p.address,
+            p.chain_id,
+            p.is_public,
+            p.sendid,
+            p.all_tags,
+            p.main_tag_id,
+            p.main_tag_name,
+            p.links_in_bio,
+            p.banner_url,
+            referrer.send_id
+           FROM (profile_lookup('sendid'::lookup_type_enum, ( SELECT (referrer_1.send_id)::text AS send_id
+                   FROM referrer referrer_1)) p(id, avatar_url, name, about, refcode, x_username, birthday, tag, address, chain_id, is_public, sendid, all_tags, main_tag_id, main_tag_name, links_in_bio, banner_url, is_verified)
+             JOIN referrer ON ((referrer.send_id IS NOT NULL)))
+        )
+ SELECT profile_lookup.id,
+    profile_lookup.avatar_url,
+    profile_lookup.name,
+    profile_lookup.about,
+    profile_lookup.refcode,
+    profile_lookup.x_username,
+    profile_lookup.birthday,
+    profile_lookup.tag,
+    profile_lookup.address,
+    profile_lookup.chain_id,
+    profile_lookup.is_public,
+    profile_lookup.sendid,
+    profile_lookup.all_tags,
+    profile_lookup.main_tag_id,
+    profile_lookup.main_tag_name,
+    profile_lookup.links_in_bio,
+    profile_lookup.send_id,
+    profile_lookup.banner_url
+   FROM profile_lookup;
+
+
+


### PR DESCRIPTION
Why:
Mirror tag_search’s is_verified computation in profile_lookup so UI can
surface verification consistently. Append the field to the end of
profile_lookup_result to minimize breakage. Update public.referrer alias
list to include the new field. Use ALTER TYPE in the migration to avoid
dropping dependent objects.

Test plan:
- Stop DB: yarn supabase stop
- Generate migration: yarn supabase migration:diff add_is_verified_to_profile_lookup
- Start DB: yarn supabase start
- Apply migration: npx supabase migration up
- Drift check: yarn supabase migration:diff changes# expect "No schema changes found"