### PR TITLE
Show verified badge on Profile

### DIFF
--- a/packages/app/features/profile/screen.tsx
+++ b/packages/app/features/profile/screen.tsx
@@ -22,7 +22,12 @@ import {
 // Internal
 import { useProfileLookup } from 'app/utils/useProfileLookup'
 import { useProfileScreenParams } from 'app/routers/params'
-import { IconAccount, IconLinkInBio } from 'app/components/icons'
+import {
+  IconAccount,
+  IconLinkInBio,
+  IconCheckCircle,
+  IconBadgeCheckSolid,
+} from 'app/components/icons'
 import { ShareOtherProfileDialog } from './components/ShareOtherProfileDialog'
 import type { Functions } from '@my/supabase/database.types'
 import { useTokenPrices } from 'app/utils/useTokenPrices'
@@ -150,9 +155,20 @@ export function ProfileScreen({ sendid: propSendid }: ProfileScreenProps) {
                 </Avatar>
               )}
               <YStack px="$4" gap="$3" jc="space-around" f={1} als="center">
-                <H3 lineHeight={32} color="$color12">
-                  {otherUserProfile?.name ?? '---'}
-                </H3>
+                <XStack ai="center" gap="$2">
+                  <H3 lineHeight={32} color="$color12">
+                    {otherUserProfile?.name ?? '---'}
+                  </H3>
+                  {otherUserProfile?.is_verified ? (
+                    <IconBadgeCheckSolid
+                      size={'$1.5'}
+                      mih={'$1.5'}
+                      miw={'$1.5'}
+                      color={'$primary'}
+                      $theme-light={{ color: '$color12' }}
+                    />
+                  ) : null}
+                </XStack>
                 <ViewHistoryButton sendId={otherUserProfile?.sendid} />
               </YStack>
             </XStack>


### PR DESCRIPTION
Why:
Mirror the existing SearchBar pattern for displaying a verified badge
(IconCheckCircle) when a profile is verified. This keeps the UI
consistent and uses the new profile_lookup.is_verified field.

Test plan:
- Open a verified user’s Profile and verify a check badge appears next
  to their name
- Open an unverified user’s Profile and verify no badge is shown