### PR TITLE
feat: improve home screen ui components add animation and interactive cards

### DIFF
--- a/packages/app/components/sidebar/HomeSideBar.tsx
+++ b/packages/app/components/sidebar/HomeSideBar.tsx
@@ -22,6 +22,7 @@ import {
   IconSendLogo,
   IconWorldSearch,
 } from 'app/components/icons'
+import { Lock } from '@tamagui/lucide-icons'
 import { SideBarNavLink } from 'app/components/sidebar/SideBarNavLink'
 
 import type { ReactElement } from 'react'
@@ -55,7 +56,7 @@ const links = [
   },
   __DEV__ || baseMainnet.id === 84532
     ? {
-        icon: <Paragraph px="$1">🔒</Paragraph>,
+        icon: <Lock size="$1" />,
         text: 'Secret shop',
         href: '/secret-shop',
       }

--- a/packages/app/features/home/InvestmentsBalanceCard.tsx
+++ b/packages/app/features/home/InvestmentsBalanceCard.tsx
@@ -13,6 +13,7 @@ import {
   useMedia,
   type ButtonProps,
   Button,
+  View,
 } from '@my/ui'
 import formatAmount, { localizeAmount } from 'app/utils/formatAmount'
 import { ChevronLeft, ChevronRight } from '@tamagui/lucide-icons'
@@ -55,7 +56,7 @@ const InvestmentsBalanceCardContent = (props: CardProps) => {
   }
 
   return (
-    <HomeBodyCard onPress={toggleSubScreen} {...props}>
+    <HomeBodyCard materialInteractive onPress={toggleSubScreen} {...props}>
       {props.children}
     </HomeBodyCard>
   )
@@ -68,6 +69,8 @@ const InvestmentsBalanceCardHomeScreenHeader = () => {
   )
   const isInvestmentsScreen = queryParams.token === 'investments'
 
+  const isChevronLeft = isInvestmentCoin || isInvestmentsScreen
+
   return (
     <Card.Header p={0} jc="space-between" fd="row">
       <Paragraph
@@ -78,20 +81,15 @@ const InvestmentsBalanceCardHomeScreenHeader = () => {
       >
         Invest
       </Paragraph>
-      {isInvestmentCoin || isInvestmentsScreen ? (
-        <ChevronLeft
-          size={'$1'}
-          color={'$primary'}
-          $theme-light={{ color: '$color12' }}
-          $lg={{ display: 'none' }}
-        />
-      ) : (
+
+      <View animateOnly={['transform']} animation="fast" rotate={isChevronLeft ? '180deg' : '0deg'}>
         <ChevronRight
-          size={'$1'}
-          color={'$lightGrayTextField'}
-          $theme-light={{ color: '$darkGrayTextField' }}
+          size="$1"
+          color={isChevronLeft ? '$primary' : '$lightGrayTextField'}
+          $theme-light={{ color: isChevronLeft ? '$color12' : '$darkGrayTextField' }}
+          $lg={{ display: isChevronLeft ? 'none' : 'flex' }}
         />
-      )}
+      </View>
     </Card.Header>
   )
 }

--- a/packages/app/features/home/StablesBalanceCard.tsx
+++ b/packages/app/features/home/StablesBalanceCard.tsx
@@ -7,6 +7,7 @@ import {
   Paragraph,
   Spinner,
   useMedia,
+  View,
   withStaticProperties,
   XStack,
 } from '@my/ui'
@@ -33,6 +34,8 @@ const StablesBalanceCardHomeScreenHeader = () => {
   )
   const isStablesScreen = queryParams.token === 'stables'
 
+  const isChevronLeft = isStableCoin || isStablesScreen
+
   return (
     <Card.Header padded size="$4" pb={0} jc="space-between" fd="row">
       <Paragraph
@@ -44,20 +47,14 @@ const StablesBalanceCardHomeScreenHeader = () => {
         Cash Balance
       </Paragraph>
       <XStack flex={1} />
-      {isStableCoin || isStablesScreen ? (
-        <ChevronLeft
-          size={'$1'}
-          color={'$primary'}
-          $theme-light={{ color: '$color12' }}
-          $lg={{ display: 'none' }}
-        />
-      ) : (
+      <View animateOnly={['transform']} animation="fast" rotate={isChevronLeft ? '180deg' : '0deg'}>
         <ChevronRight
-          size={'$1'}
-          color={'$lightGrayTextField'}
-          $theme-light={{ color: '$darkGrayTextField' }}
+          size="$1"
+          color={isChevronLeft ? '$primary' : '$lightGrayTextField'}
+          $theme-light={{ color: isChevronLeft ? '$color12' : '$darkGrayTextField' }}
+          $lg={{ display: isChevronLeft ? 'none' : 'flex' }}
         />
-      )}
+      </View>
     </Card.Header>
   )
 }
@@ -217,10 +214,10 @@ export const StablesBalanceCardContent = (props: CardProps) => {
     <Card
       w="100%"
       onPress={toggleSubScreen}
-      cursor="pointer"
       size={'$5'}
       br="$7"
       p={'$1.5'}
+      materialInteractive
       {...props}
     >
       {props.children}

--- a/packages/app/features/home/screen.tsx
+++ b/packages/app/features/home/screen.tsx
@@ -81,6 +81,7 @@ export function HomeScreen() {
                 <HomeBody
                   key="home-body"
                   animation="200ms"
+                  animateOnly={['opacity', 'transform']}
                   enterStyle={{
                     opacity: 0,
                     y: media.gtLg ? 0 : 300,
@@ -133,7 +134,7 @@ function HomeBody(props: XStackProps) {
             </StablesBalanceCard.Footer>
           </StablesBalanceCard>
           <SavingsBalanceCard href="/earn" w="100%" />
-          <InvestmentsBalanceCard padded size="$5" gap="$3" w="100%">
+          <InvestmentsBalanceCard padded gap="$3" w="100%">
             <InvestmentsBalanceCard.HomeScreenHeader />
             <Card.Footer jc="space-between" ai="center">
               <YStack gap="$3">
@@ -151,20 +152,22 @@ function HomeBody(props: XStackProps) {
             <FriendsCard href="/account/affiliate" />
           </HomeBodyCardRow>
         </YStack>
-        {(() => {
-          switch (true) {
-            case Platform.OS !== 'web':
-              return null
-            case selectedCoin !== undefined:
-              return <TokenDetails />
-            case queryParams.token === 'investments':
-              return <InvestmentsBody />
-            case queryParams.token === 'stables':
-              return <StablesBody />
-            default:
-              return null
-          }
-        })()}
+        <AnimatePresence>
+          {(() => {
+            switch (true) {
+              case Platform.OS !== 'web':
+                return null
+              case selectedCoin !== undefined:
+                return <TokenDetails />
+              case queryParams.token === 'investments':
+                return <InvestmentsBody />
+              case queryParams.token === 'stables':
+                return <StablesBody />
+              default:
+                return null
+            }
+          })()}
+        </AnimatePresence>
       </XStack>
     </IsPriceHiddenProvider>
   )
@@ -213,8 +216,27 @@ export function InvestmentsBody() {
   const formattedDeltaUSD = localizeAmount(Math.abs(delta24hUSD).toFixed(2))
   const sign = delta24hUSD >= 0 ? '+' : '-'
 
+  const media = useMedia()
+
   return (
-    <YStack ai="center" $gtXs={{ gap: '$3' }} gap={'$3.5'} f={1}>
+    <YStack
+      key={media.gtLg ? 'investments-body-lg' : 'investments-body-xs'}
+      {...(media.gtLg && {
+        animation: '100ms',
+        enterStyle: {
+          o: 0,
+          x: -30,
+        },
+        exitStyle: {
+          o: 0,
+          x: -20,
+        },
+      })}
+      ai="center"
+      $gtXs={{ gap: '$3' }}
+      gap={'$3.5'}
+      f={1}
+    >
       <InvestmentsPortfolioCard padded size="$6" w="100%" mah={220} gap="$5">
         <Card.Header p={0}>
           <Paragraph
@@ -313,9 +335,7 @@ export function InvestmentsBody() {
 
       {/* Holdings list */}
       <YStack w={'100%'} gap={'$2'}>
-        <H4 fontWeight={600} size={'$7'}>
-          Your Holdings
-        </H4>
+        <H4 size="$7">Your Holdings</H4>
         <Card
           bc={'$color1'}
           width="100%"
@@ -356,13 +376,30 @@ export function InvestmentsBody() {
   )
 }
 
-export function StablesBody() {
+export const StablesBody = YStack.styleable((props) => {
   const media = useMedia()
 
   return (
-    <YStack $gtXs={{ gap: '$3' }} gap={'$3.5'} f={1}>
+    <YStack
+      key={media.gtLg ? 'stables-body-lg' : 'stables-body-xs'}
+      {...(media.gtLg && {
+        animation: '100ms',
+        enterStyle: {
+          o: 0,
+          x: -30,
+        },
+        exitStyle: {
+          o: 0,
+          x: -20,
+        },
+      })}
+      $gtXs={{ gap: '$3' }}
+      gap={'$3.5'}
+      f={1}
+      {...props}
+    >
       {media.lg && (
-        <StablesBalanceCard>
+        <StablesBalanceCard materialInteractive={false}>
           <StablesBalanceCard.StablesScreenHeader />
           <StablesBalanceCard.Footer>
             <StablesBalanceCard.Balance />
@@ -381,7 +418,9 @@ export function StablesBody() {
       </Card>
     </YStack>
   )
-}
+})
+
+StablesBody.displayName = 'StablesBody'
 
 export const HomeBodyCard = styled(Card, {
   size: '$5',
@@ -389,6 +428,7 @@ export const HomeBodyCard = styled(Card, {
   f: 1,
   mah: 150,
   p: '$1.5',
+  materialInteractive: true,
 })
 
 export const HomeBodyCardRow = styled(XStack, {

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -19,6 +19,21 @@ export const CardFrame = styled(ThemeableStack, {
         position: 'relative',
       },
     },
+    materialInteractive: {
+      true: {
+        cursor: 'pointer',
+        focusable: true,
+        hoverStyle: {
+          elevation: '$0.9',
+        },
+        pressStyle: {
+          elevation: '$0.75',
+        },
+        '$platform-web': {
+          transition: 'box-shadow 150ms ease',
+        },
+      },
+    },
 
     size: {
       '...size': (val, { tokens }) => {


### PR DESCRIPTION
### TLDR;
Improve home page ui elements

### Changes
- card elements on home screen have hover and press style ( visible in light mode ), pointer cursor, and consistent corner radius
- card elements will capture focus as well, good for a11y, chevrons on Card are animated
- sub content enter/exist has transition animation

https://github.com/user-attachments/assets/e0e7ddf5-c9fb-4de8-89d2-a4c9e099eff7


