### PR TITLE
chore(workflows): rename staging environment to dev

### DIFF
--- a/.github/workflows/build-distributor.yml
+++ b/.github/workflows/build-distributor.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: 'Environment name (staging, production)'
+        description: 'Environment name (dev, production)'
         required: true
         type: string
     outputs:
@@ -14,13 +14,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment name (staging, production)'
+        description: 'Environment name (dev, production)'
         required: true
         type: choice
         options:
-          - staging
+          - dev
           - production
-        default: staging
+        default: dev
 
 jobs:
   build-distributor:

--- a/.github/workflows/build-shovel.yml
+++ b/.github/workflows/build-shovel.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: 'Environment name (staging, production)'
+        description: 'Environment name (dev, production)'
         required: true
         type: string
     outputs:
@@ -14,13 +14,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment name (staging, production)'
+        description: 'Environment name (dev, production)'
         required: true
         type: choice
         options:
-          - staging
+          - dev
           - production
-        default: staging
+        default: dev
 
 jobs:
   build-shovel:

--- a/.github/workflows/build-workers.yml
+++ b/.github/workflows/build-workers.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: 'Environment name (staging, production)'
+        description: 'Environment name (dev, production)'
         required: true
         type: string
     outputs:
@@ -14,13 +14,13 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment name (staging, production)'
+        description: 'Environment name (dev, production)'
         required: true
         type: choice
         options:
-          - staging
+          - dev
           - production
-        default: staging
+        default: dev
 
 jobs:
   build-workers:


### PR DESCRIPTION
## Summary
- Renamed 'staging' to 'dev' across all build workflows for consistency
- Updated `build-distributor.yml`, `build-workers.yml`, and `build-shovel.yml`
- Docker image tags will now use `dev-latest` and `dev-{sha}` instead of `staging-latest` and `staging-{sha}`

## Motivation
Aligns workflow environment naming with the actual development environment used in the project.

## Test plan
- [ ] Verify workflow can be manually triggered with 'dev' environment option
- [ ] Confirm Docker images are tagged correctly after build

🤖 Generated with [Claude Code](https://claude.ai/code)