### PR TITLE
prod: optimize shovel batch_size and concurrency for Supabase pooler timeout

### DIFF
--- a/packages/shovel/etc/config.json
+++ b/packages/shovel/etc/config.json
@@ -21,8 +21,8 @@
     },
     {
       "name": "base_logs",
-      "batch_size": 2000,
-      "concurrency": 2,
+      "batch_size": 10,
+      "concurrency": 8,
       "chain_id": "$BASE_CHAIN_ID",
       "url": "$BASE_RPC_URL_PRIMARY",
       "urls": [


### PR DESCRIPTION
## Summary
- Optimizes shovel configuration to prevent Supabase pooler idle-in-transaction timeouts
- Reduces batch_size from 2000→10 and increases concurrency from 2→8
- Configuration tested and proven stable in production during incident resolution

## Root Cause
Supabase connection pooler enforces ~30s idle-in-transaction timeout (not visible in pg_settings). Large batches with complex database triggers on `send_account_transfers` exceeded this limit, causing statement timeouts.

## Testing Results
Systematically tested configurations in production:
- ❌ batch_size=2000, concurrency=2 → Statement timeout (>5min)
- ❌ batch_size=1000, concurrency=1 → Statement timeout
- ❌ batch_size=25, concurrency=8 → Statement timeout
- ❌ batch_size=15, concurrency=8 → Statement timeout
- ✅ batch_size=10, concurrency=8 → **STABLE** (optimal)
- ❌ batch_size=10, concurrency=16 → Shovel panic (index out of range)
- ❌ batch_size=5, concurrency=8 → Shovel panic

## Optimal Configuration
- **batch_size**: 10 blocks (keeps transactions under pooler timeout)
- **concurrency**: 8 workers (maximum stable parallelism)
- **Performance**: ~80 blocks/min catchup rate

## Test Plan
- [x] Tested in production during incident resolution
- [x] Verified stable operation over extended period
- [x] Confirmed catchup performance meets requirements
- [ ] Deploy to dev environment for validation
- [ ] Monitor production after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)